### PR TITLE
Change default branch from 'master' to 'main'

### DIFF
--- a/.github/steps/create-issue-if-override-files-updated
+++ b/.github/steps/create-issue-if-override-files-updated
@@ -21,5 +21,5 @@ echo $UPDATE_CHECK_EXIT_CODE
 echo $NG_CHECK_EXIT_CODE
 
 if [ $UPDATE_CHECK_EXIT_CODE -ne 0 -a $NG_CHECK_EXIT_CODE -eq 0 ] ; then
-  gh issue create --title "Upstream files overridden are updated" --body "Upstream files overridden are updated. see https://github.com/quarkusio/pt.quarkus.io/blob/master/l10n/stats/override.csv for more details."
+  gh issue create --title "Upstream files overridden are updated" --body "Upstream files overridden are updated. see https://github.com/quarkusio/pt.quarkus.io/blob/main/l10n/stats/override.csv for more details."
 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   schedule:
     # everyday 9AM (UTC)
     - cron: '0 9 * * *'
@@ -12,7 +12,7 @@ on:
     workflows:
       - 'sync-upstream'
     branches:
-      - 'master'
+      - 'main'
     types:
       - completed
 


### PR DESCRIPTION
Since `quarkus-l10n-utils` scripts presupposes that the default branch is `main`, the default branch need to be changed to `main`.
This pull-request updates the GitHub workflow definitions before chaning the default branch.