### PR TITLE
Disable machine translation temporarily

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -57,11 +57,11 @@ jobs:
         # Commit and Push the .po files updated by tmx
         run: vendor/quarkus-l10n-utils/bin/push-changes "Apply translation memory"
 
-      - name: Machine translate
-        # Machine translate with DeepL API
-        run: vendor/quarkus-l10n-utils/bin/translate-po-files-with-deepl
-        env:
-          TRANSLATOR_DEEPL_APIKEY: ${{ secrets.TRANSLATOR_DEEPL_APIKEY }}
+#      - name: Machine translate
+#        # Machine translate with DeepL API
+#        run: vendor/quarkus-l10n-utils/bin/translate-po-files-with-deepl
+#        env:
+#          TRANSLATOR_DEEPL_APIKEY: ${{ secrets.TRANSLATOR_DEEPL_APIKEY }}
 
       - name: Push changes
         # Commit and Push the .po files updated by DeepL machine-translation


### PR DESCRIPTION
not to eat up DeepL credits by translating new Quarkus minior version docs
With current implementation, translations marked with "fuzzy" are not reused for translating sentences. 
This eat up a lot of DeepL credits when a new Quarkus minor version is released. 
Once the reuse of translations marked with "fuzzy" are implemented, macihne translation can be enabled again.
(Hopefully within 1 or 2 weeks)
