### PR TITLE
Add fuzzy tmx support, and enable machine translation again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,25 @@ jobs:
         # Setup build environment(install runtime, library, etc.)
         run: |
           bin/setup-build-env-on-ubuntu
+
+      - name: Update fuzzy tmx
+        # Update fuzzy tmx file from .po files
+        # Translation memory is a kind of dictionary consisted by pairs of a original text and a translated text.
+        # fuzzy.tmx will be used in sync workflow to fill a machine translated text candidates to the updated .po files.
+        run: vendor/quarkus-l10n-utils/bin/update-tmx
+
+      - name: Push changes
+        # Commit and Push the fuzzy tmx file generated
+        run: vendor/quarkus-l10n-utils/bin/push-changes "Update fuzzy tmx"
+
       - name: Update tmx
-        # Update .tmx (translation memory) file from .po files
+        # Update tmx file from .po files
         # Translation memory is a kind of dictionary consisted by pairs of a original text and a translated text.
         # It will be used in sync workflow to fill a translated text to the updated .po files.
         run: vendor/quarkus-l10n-utils/bin/update-tmx
 
       - name: Push changes
-        # Commit and Push the .tmx file generated
+        # Commit and Push the tmx file generated
         run: vendor/quarkus-l10n-utils/bin/push-changes "Update tmx"
 
       - name: Update translation stats

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -49,6 +49,14 @@ jobs:
         # Commit and Push the translation stats .csv file
         run: vendor/quarkus-l10n-utils/bin/push-changes "Update translation stats"
 
+      - name: Apply fuzzy tmx
+        # Apply fuzzy tmx to .po files to fill fuzzy translation candidates
+        run: vendor/quarkus-l10n-utils/bin/translate-po-files-with-tmx
+
+      - name: Push changes
+        # Commit and Push the .po files updated by fuzzy tmx
+        run: vendor/quarkus-l10n-utils/bin/push-changes "Apply fuzzy translation memory"
+
       - name: Apply tmx
         # Apply tmx file to .po files to fill known translations
         run: vendor/quarkus-l10n-utils/bin/translate-po-files-with-tmx
@@ -57,11 +65,11 @@ jobs:
         # Commit and Push the .po files updated by tmx
         run: vendor/quarkus-l10n-utils/bin/push-changes "Apply translation memory"
 
-#      - name: Machine translate
-#        # Machine translate with DeepL API
-#        run: vendor/quarkus-l10n-utils/bin/translate-po-files-with-deepl
-#        env:
-#          TRANSLATOR_DEEPL_APIKEY: ${{ secrets.TRANSLATOR_DEEPL_APIKEY }}
+      - name: Machine translate
+        # Machine translate with DeepL API
+        run: vendor/quarkus-l10n-utils/bin/translate-po-files-with-deepl
+        env:
+          TRANSLATOR_DEEPL_APIKEY: ${{ secrets.TRANSLATOR_DEEPL_APIKEY }}
 
       - name: Push changes
         # Commit and Push the .po files updated by DeepL machine-translation

--- a/bin/setup-build-env-on-ubuntu
+++ b/bin/setup-build-env-on-ubuntu
@@ -18,7 +18,7 @@ sudo gem install bundler
 sudo npm --global install surge
 
 export DOC_L10N_KIT_VERSION=`jq ".[\"doc-l10n-kit\"].version" config/l10n-utils.json -r`
-export DOC_L10N_UTILS_BRANCH=`jq ".[\"doc-l10n-utils\"].branch" config/l10n-utils.json -r`
+export DOC_L10N_UTILS_VERSION=`jq ".[\"doc-l10n-utils\"].version" config/l10n-utils.json -r`
 export PO4A_BRANCH=`jq ".[\"po4a\"].branch" config/l10n-utils.json -r`
 
 mkdir -p vendor
@@ -29,7 +29,7 @@ git submodule update
 curl -L https://github.com/doc-l10n-kit/doc-l10n-kit/releases/download/$DOC_L10N_KIT_VERSION/doc-l10n-kit-runner.jar -o vendor/doc-l10n-kit-runner.jar
 
 rm -rf vendor/quarkus-l10n-utils
-git clone https://github.com/doc-l10n-kit/quarkus-l10n-utils.git vendor/quarkus-l10n-utils -b $DOC_L10N_UTILS_BRANCH
+git clone https://github.com/doc-l10n-kit/quarkus-l10n-utils.git vendor/quarkus-l10n-utils -b $DOC_L10N_UTILS_VERSION
 
 rm -rf vendor/po4a
 git clone https://github.com/doc-l10n-kit/po4a.git vendor/po4a -b $PO4A_BRANCH

--- a/config/l10n-utils.json
+++ b/config/l10n-utils.json
@@ -2,6 +2,7 @@
   "targetLang": "pt_BR",
   "tmx": {
     "filePath": "l10n/tmx/quarkus.tmx",
+    "fuzzyFilePath": "l10n/tmx/fuzzy.tmx",
     "similarity": 100
   },
   "git": {
@@ -11,10 +12,10 @@
     }
   },
   "doc-l10n-kit":{
-    "version": "0.9.3.RELEASE"
+    "version": "0.9.4.RELEASE"
   },
   "doc-l10n-utils":{
-    "branch": "main"
+    "version": "0.5.1"
   },
   "po4a":{
     "branch": "v0.66-mod1"


### PR DESCRIPTION
fuzzy.tmx is added. 
The GitHub Actions build' workflow extracts fuzzy (=machine-translated, but not reviewed) sentences translations from .po files into this fuzzy.tmx file.
the file is used for filling .po files' sentences during the GitHub Actions 'sync' workflow.

With this change, the machine-translations  are reused across files and DeepL usage can be saved.

Also, machine translation step is enabled again.