### PR TITLE
Enable fuzzy tmx compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         # Update fuzzy tmx file from .po files
         # Translation memory is a kind of dictionary consisted by pairs of a original text and a translated text.
         # fuzzy.tmx will be used in sync workflow to fill a machine translated text candidates to the updated .po files.
-        run: vendor/quarkus-l10n-utils/bin/update-tmx
+        run: vendor/quarkus-l10n-utils/bin/update-fuzzy-tmx
 
       - name: Push changes
         # Commit and Push the fuzzy tmx file generated

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Apply fuzzy tmx
         # Apply fuzzy tmx to .po files to fill fuzzy translation candidates
-        run: vendor/quarkus-l10n-utils/bin/translate-po-files-with-tmx
+        run: vendor/quarkus-l10n-utils/bin/translate-po-files-with-fuzzy-tmx
 
       - name: Push changes
         # Commit and Push the .po files updated by fuzzy tmx


### PR DESCRIPTION
fuzzy.tmx is a file to store sentences already machine translated, but not human reviewed for future reuse.
Since fuzzy.tmx compilation is not enabled by mistake, these sentences are not reused.
This commit enables fuzzy.tmx compilation
