### PR TITLE
Main

### DIFF
--- a/l10n/po/pt_BR/_guides/cli-tooling.adoc.po
+++ b/l10n/po/pt_BR/_guides/cli-tooling.adoc.po
@@ -6,374 +6,344 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: 2023-10-29 08:09+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2024-04-17 17:51+0300\n"
+"Last-Translator: Arthur Gularte Brandi <arthurgularte80@gmail.com>\n"
+"Language-Team: \n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. This guide is maintained in the main Quarkus repository
 #. and pull requests should be submitted there:
 #. https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 #. type: Title =
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Building Quarkus apps with Quarkus Command Line Interface (CLI)"
-msgstr "Criação de aplicativos Quarkus com a interface de linha de comando (CLI) do Quarkus"
+msgstr "Criar aplicações Quarkus com a interface de linha de comandos (CLI) do Quarkus"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "The `quarkus` command lets you create projects, manage extensions and\n"
 "do essential build and development tasks using the underlying project build tool."
-msgstr "O comando `quarkus` permite que o senhor crie projetos, gerencie extensões e realize tarefas essenciais de criação e desenvolvimento usando a ferramenta de criação de projetos subjacente."
+msgstr "O comando `quarkus` permite que você crie projetos, gerencie extensões e realize tarefas essenciais de criação e desenvolvimento usando a ferramenta de criação de projetos subjacente."
 
 #. type: Title ==
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Installing the CLI"
-msgstr "Instalação da CLI"
+msgstr "Instalação do CLI"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The Quarkus CLI is available in several developer-oriented package managers such as:"
-msgstr "A CLI do Quarkus está disponível em vários gerenciadores de pacotes voltados para o desenvolvedor, como o"
+msgstr "O Quarkus CLI está disponível em vários gestores de pacotes orientados para o desenvolvedor, tais como:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "https://sdkman.io[SDKMAN!]"
 msgstr "link:https://sdkman.io[SDKMAN!]"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "https://brew.sh[Homebrew]"
 msgstr "link:https://brew.sh[Homebrew]"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "https://community.chocolatey.org/packages/quarkus[Chocolatey]"
-msgstr "link:https://community.chocolatey.org/packages/quarkus[Com chocolate]"
+msgstr "link:https://community.chocolatey.org/packages/quarkus[Chocolatey]"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "https://scoop.sh[Scoop]"
-msgstr "link:https://scoop.sh[Foco]"
+msgstr "link:https://scoop.sh[Scoop]"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "If you already use (or want to use) one of these tools, it is the simplest way to install the Quarkus CLI and keep it updated."
-msgstr "Se o senhor já usa (ou deseja usar) uma dessas ferramentas, essa é a maneira mais simples de instalar a CLI do Quarkus e mantê-la atualizada."
+msgstr "Se você já utiliza (ou pretende utilizar) uma destas ferramentas, esta é a forma mais simples de instalar o Quarkus CLI e de o manter atualizado."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "In addition to these package managers, the Quarkus CLI is also installable via https://www.jbang.dev[JBang].\n"
 "Choose the alternative that is the most practical for you:"
-msgstr "Além desses gerenciadores de pacotes, o Quarkus CLI também pode ser instalado via link:https://www.jbang.dev[JBang] . Escolha a alternativa que for mais prática para o senhor:"
+msgstr ""
+"Além desses gestores de pacotes, o Quarkus CLI também pode ser instalado via link:https://www.jbang.dev[JBang].\n"
+"Escolha a alternativa que for mais prática para você:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "JBang - for Linux, macOS and Windows"
 msgstr "JBang - para Linux, macOS e Windows"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "SDKMAN! - for Linux and macOS"
 msgstr "SDKMAN! - para Linux e macOS"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Homebrew - for Linux and macOS"
 msgstr "Homebrew - para Linux e macOS"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Chocolatey - for Windows"
 msgstr "Chocolatey - para Windows"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Scoop - for Windows"
 msgstr "Scoop - para Windows"
 
 #. type: Block title
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "JBang"
 msgstr "JBang"
 
 #. type: delimited block *
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The Quarkus CLI is available as a jar installable using https://jbang.dev[JBang]."
-msgstr "O Quarkus CLI está disponível como um jar instalável usando link:https://jbang.dev[o JBang] ."
+msgstr "O Quarkus CLI está disponível como um jar instalável usando o link:https://jbang.dev[JBang] ."
 
 #. type: delimited block *
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "JBang will use your existing Java or install one for you if needed."
-msgstr "O JBang usará o Java existente ou instalará um para o senhor, se necessário."
+msgstr "O JBang utilizará o Java existente ou instalará um para você, se necessário."
 
 #. type: delimited block *
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "On Linux, macOS, and Windows (using WSL or bash compatible shell like Cygwin or MinGW)"
-msgstr "No Linux, macOS e Windows (usando WSL ou shell compatível com bash, como Cygwin ou MinGW)"
+msgstr "No Linux, macOS e Windows (usando WSL ou shell compatível com bash como Cygwin ou MinGW)"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "On Windows using Powershell:"
 msgstr "No Windows, usando o Powershell:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "If JBang has already been installed, you can directly use it:"
-msgstr "Se o JBang já tiver sido instalado, o senhor poderá usá-lo diretamente:"
+msgstr "Se o JBang já tiver sido instalado, você pode utilizá-lo diretamente:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "If you want to use a specific version, you can directly target a version:"
-msgstr "Se quiser usar uma versão específica, o senhor pode direcionar diretamente uma versão:"
+msgstr "Se pretender utilizar uma versão específica, você pode definir diretamente uma versão como alvo:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "If you have built Quarkus locally, you can use that version:"
-msgstr "Se o senhor tiver criado o Quarkus localmente, poderá usar essa versão:"
+msgstr "Se você tiver criado o Quarkus localmente, poderá usar essa versão:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Once installed `quarkus` will be in your `$PATH` and if you run `quarkus --version` it will print the installed version:"
-msgstr "Uma vez instalado, o `quarkus` estará no seu `$PATH` e, se o senhor executar o `quarkus --version` , ele imprimirá a versão instalada:"
+msgstr "Uma vez instalado, o `quarkus` estará no seu `$PATH` e se você executar `quarkus --version` ele mostrará a versão instalada:"
 
 #. type: Block title
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Use a recent JBang version"
 msgstr "Use uma versão recente do JBang"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "If you get an error about `app` not being readable then you probably\n"
 "have a JBang version older than v0.56.0 installed. Please remove or upgrade it to a recent version."
-msgstr "Se o senhor receber um erro sobre `app` não ser legível, provavelmente tem instalada uma versão do JBang anterior à v0.56.0. Remova ou atualize-a para uma versão mais recente."
+msgstr "Se você encontrar um erro sobre `app` não ser legível (`app` not being readable), então você provavelmente tem uma versão do JBang mais antiga que a v0.56.0 instalada. Por favor, remova ou atualize-a para uma versão mais recente."
 
 #. type: delimited block =
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "If you are installing JBang for the first time, start a new session to update your `PATH`."
-msgstr "Se o senhor estiver instalando o JBang pela primeira vez, inicie uma nova sessão para atualizar o site `PATH` ."
+msgstr "Se você está instalando o JBang pela primeira vez, inicie uma nova sessão para atualizar seu `PATH`."
 
 #. type: Block title
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "SDKMAN!"
 msgstr "SDKMAN!"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "https://sdkman.io/[SDKMAN!] can be used to manage development environments.\n"
 "It can manage parallel versions of multiple Software Development Kits on most Unix based systems,\n"
 "making it a very good alternative to keep multiple JDK versions handy."
-msgstr "O link:https://sdkman.io/[SDKMAN!] pode ser usado para gerenciar ambientes de desenvolvimento. Ele pode gerenciar versões paralelas de vários kits de desenvolvimento de software na maioria dos sistemas baseados em Unix, o que o torna uma alternativa muito boa para manter várias versões do JDK à mão."
+msgstr ""
+"link:https://sdkman.io/[SDKMAN!] pode ser usado para gerir ambientes de desenvolvimento.\n"
+"Ele pode gerenciar versões paralelas de múltiplos SDKs (Software Development Kits) na maioria dos sistemas baseados em Unix, \n"
+"tornando-o uma alternativa muito boa para manter várias versões do JDK à mão."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "With SDKMAN!, you can also install popular Java tools, including the Quarkus CLI."
-msgstr "Com o SDKMAN!, o senhor também pode instalar ferramentas Java populares, incluindo a CLI do Quarkus."
+msgstr "Com o SDKMAN!, você também pode instalar ferramentas Java populares, incluindo o Quarkus CLI."
 
 #. type: delimited block =
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Make sure you have https://sdkman.io/jdks[a JDK installed] before installing the Quarkus CLI."
-msgstr "Certifique-se de que o senhor tenha link:https://sdkman.io/jdks[um JDK instalado] antes de instalar o Quarkus CLI."
+msgstr "Certifique-se de que você tenha um link:https://sdkman.io/jdks[JDK] instalado antes de instalar o Quarkus CLI."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "To list the available versions of Java, use `sdk list java`.\n"
 "You can then install the version of OpenJDK you want with `sdk install java x.y.z-open`\n"
 "(or the JDK of another vendor if it is your preference)."
-msgstr "Para listar as versões disponíveis do Java, use `sdk list java` . Em seguida, o senhor pode instalar a versão do OpenJDK que desejar com `sdk install java x.y.z-open` (ou o JDK de outro fornecedor, se for de sua preferência)."
+msgstr ""
+"Para listar as versões disponíveis do Java, use `sdk list java`.\n"
+"Você pode instalar a versão do OpenJDK que preferir com `sdk install java x.y.z-open`\n"
+"(ou o JDK de outro fornecedor se for de sua preferência)."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "To install the Quarkus CLI using SDKMAN!, run the following command:"
 msgstr "Para instalar o Quarkus CLI usando o SDKMAN!, execute o seguinte comando:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "It will install the latest version of the Quarkus CLI."
-msgstr "Ele instalará a versão mais recente da CLI do Quarkus."
+msgstr "Ele instalará a versão mais recente do Quarkus CLI."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "SDKMAN! will let you know when new versions are available so updates will be straightforward:"
-msgstr "O SDKMAN! avisará o senhor quando novas versões estiverem disponíveis para que as atualizações sejam simples:"
+msgstr "SDKMAN! irá informá-lo quando novas versões estiverem disponíveis para que as atualizações sejam simples:"
 
 #. type: Block title
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Homebrew"
 msgstr "Homebrew"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "https://brew.sh[Homebrew] is a package manager for macOS (and Linux)."
-msgstr "link:https://brew.sh[O Homebrew] é um gerenciador de pacotes para macOS (e Linux)."
+msgstr "link:https://brew.sh[Homebrew] é um gerenciador de pacotes para macOS (e Linux)."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "You can use Homebrew to install (and update) the Quarkus CLI."
-msgstr "O senhor pode usar o Homebrew para instalar (e atualizar) a CLI do Quarkus."
+msgstr "Você pode usar o Homebrew para instalar (e atualizar) o CLI do Quarkus."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "Make sure you have a JDK installed before installing the Quarkus CLI.\n"
 "We haven't added an explicit dependency as we wanted to make sure you could use your preferred JDK version."
-msgstr "Certifique-se de que o senhor tenha um JDK instalado antes de instalar a CLI do Quarkus. Não adicionamos uma dependência explícita porque queríamos ter certeza de que o senhor poderia usar sua versão preferida do JDK."
+msgstr ""
+"Certifique-se de que você tenha um JDK instalado antes de instalar o Quarkus CLI.\n"
+"Não adicionamos uma dependência específica porque visamos garantir que você possa usar sua versão preferida do JDK."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "You can install a JDK with `brew install openjdk` for the latest Java version, `brew install openjdk@17` for Java 17, or `brew install openjdk@21` for Java 21."
-msgstr "O senhor pode instalar um JDK com `brew install openjdk` para a versão mais recente do Java, `brew install openjdk@17` para o Java 17 ou `brew install openjdk@21` para o Java 21."
+msgstr "Você pode instalar um JDK com `brew install openjdk` para a última versão do Java, `brew install openjdk@17` para Java 17, ou `brew install openjdk@21` para Java 21."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "To install the Quarkus CLI using Homebrew, run the following command:"
 msgstr "Para instalar o Quarkus CLI usando o Homebrew, execute o seguinte comando:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "It will install the latest version of the Quarkus CLI.\n"
 "This command can also be used to update the Quarkus CLI."
-msgstr "Ele instalará a versão mais recente da CLI do Quarkus. Esse comando também pode ser usado para atualizar a CLI do Quarkus."
+msgstr ""
+"Ele instalará a versão mais recente do Quarkus CLI.\n"
+"Esse comando também pode ser usado para atualizar o Quarkus CLI."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "You can upgrade the Quarkus CLI with:"
-msgstr "O senhor pode atualizar a CLI do Quarkus com:"
+msgstr "Você pode atualizar o Quarkus CLI com:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Update all package definitions and Homebrew itself"
-msgstr "Atualizar todas as definições de pacotes e o próprio Homebrew"
+msgstr "Atualiza todas as definições de pacotes e o próprio Homebrew"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Upgrade Quarkus CLI to the latest version"
-msgstr "Atualize o Quarkus CLI para a versão mais recente"
+msgstr "Atualiza o Quarkus CLI para a versão mais recente"
 
 #. type: Block title
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Chocolatey"
-msgstr "Com chocolate"
+msgstr "Chocolatey"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "https://chocolatey.org[Chocolatey] is a package manager for Windows."
-msgstr "link:https://chocolatey.org[O Chocolatey] é um gerenciador de pacotes para Windows."
+msgstr "https://chocolatey.org[Chocolatey] é um gestor de pacotes para Windows."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "You can use Chocolatey to install (and update) the Quarkus CLI."
-msgstr "O senhor pode usar o Chocolatey para instalar (e atualizar) a CLI do Quarkus."
+msgstr "Você pode usar o Chocolatey para instalar (e atualizar) o Quarkus CLI."
 
 #. type: delimited block =
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Make sure you have a JDK installed before installing the Quarkus CLI."
-msgstr "Certifique-se de que o senhor tenha um JDK instalado antes de instalar o Quarkus CLI."
+msgstr "Certifique-se de que você tenha um JDK instalado antes de instalar o Quarkus CLI."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "You can install a JDK with `choco install temurin17` for Java 17 or `choco install temurin21` for Java 21."
-msgstr "O senhor pode instalar um JDK com `choco install temurin17` para Java 17 ou `choco install temurin21` para Java 21."
+msgstr "Você pode instalar um JDK com `choco install temurin17` para Java 17 ou `choco install temurin21` para Java 21."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "To install the Quarkus CLI using Chocolatey, run the following command:"
 msgstr "Para instalar o Quarkus CLI usando o Chocolatey, execute o seguinte comando:"
 
 #. type: Block title
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Scoop"
-msgstr "Foco"
+msgstr "Scoop"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "https://scoop.sh[Scoop] is a package manager for Windows.\n"
 "You can use Scoop to install (and update) the Quarkus CLI."
-msgstr "link:https://scoop.sh[O Scoop] é um gerenciador de pacotes para Windows. O senhor pode usar o Scoop para instalar (e atualizar) a CLI do Quarkus."
+msgstr ""
+"link:https://scoop.sh[Scoop] é um gestor de pacotes para Windows.\n"
+"Você pode usar o Scoop para instalar (e atualizar) o Quarkus CLI."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "Make sure you have a JDK installed before installing the Quarkus CLI.\n"
 "You can install a JDK with `scoop install openjdk17` for Java 17 or `scoop install openjdk21` for Java 21."
-msgstr "Certifique-se de que o senhor tenha um JDK instalado antes de instalar a CLI do Quarkus. O senhor pode instalar um JDK com `scoop install openjdk17` para Java 17 ou `scoop install openjdk21` para Java 21."
+msgstr ""
+"Certifique-se de que você tenha um JDK instalado antes de instalar o Quarkus CLI.\n"
+"Você pode instalar um JDK com `scoop install openjdk17` para Java 17 ou `scoop install openjdk21` para Java 21."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "To install the Quarkus CLI using Scoop, run the following command:"
 msgstr "Para instalar o Quarkus CLI usando o Scoop, execute o seguinte comando:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "It will install the latest version of the Quarkus CLI.\n"
 "Once installed `quarkus` will be in your `$PATH` and if you run `quarkus --version` it will print the installed version:"
-msgstr "Ele instalará a versão mais recente da CLI do Quarkus. Uma vez instalado, o `quarkus` estará no seu `$PATH` e, se o senhor executar o `quarkus --version` , ele imprimirá a versão instalada:"
+msgstr ""
+"Ele instalará a versão mais recente do Quarkus CLI.\n"
+"Uma vez instalado, o `quarkus` estará no seu `$PATH` e se você executar `quarkus --version` ele mostrará a versão instalada:"
 
 #. type: Title ==
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Using the CLI"
-msgstr "Usando a CLI"
+msgstr "Usando o CLI"
 
 #. type: delimited block *
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Use `--help` to display help information with all the available commands:"
 msgstr "Use `--help` para exibir informações de ajuda com todos os comandos disponíveis:"
 
@@ -381,626 +351,584 @@ msgstr "Use `--help` para exibir informações de ajuda com todos os comandos di
 #: _guides/cli-tooling.adoc
 #, fuzzy
 msgid "While this document is a useful reference, the client help is the definitive source."
-msgstr "Embora este documento seja uma referência útil, a ajuda do cliente é a fonte definitiva."
+msgstr "Embora este documento seja uma referência útil, o suporte ao cliente é a fonte definitiva."
 
 #. type: delimited block =
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "If you don't see the output you expect, use `--help` to verify that you are invoking the command with the right arguments."
-msgstr "Se não vir a saída esperada, use `--help` para verificar se o comando está sendo invocado com os argumentos corretos."
+msgstr "Se você não visualizar o resultado esperado, use `--help` para verificar se está invocando o comando com os argumentos corretos."
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Creating a new project"
-msgstr "Criar um novo projeto"
+msgstr "Criando um novo projeto"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "To create a new project, use the `create` command\n"
 "(the `app` subcommand is implied when not specified):"
-msgstr "Para criar um novo projeto, use o comando `create` (o subcomando `app` está implícito quando não é especificado):"
+msgstr ""
+"Para criar um novo projeto, use o comando `create`\n"
+"(o subcomando `app` estará implícito quando não é especificado):"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "This will create a folder called `code-with-quarkus` in your current working directory using default `groupId`, `artifactId` and `version` values\n"
 "(`groupId='org.acme'`, `artifactId='code-with-quarkus'` and `version='1.0.0-SNAPSHOT'`)."
-msgstr "Isso criará uma pasta chamada `code-with-quarkus` em seu diretório de trabalho atual usando os valores padrão `groupId` , `artifactId` e `version` ( `groupId='org.acme'` , `artifactId='code-with-quarkus'` e `version='1.0.0-SNAPSHOT'` )."
+msgstr ""
+"Isso criará uma pasta chamada `code-with-quarkus` em seu diretório de trabalho atual usando os valores padrão `groupId` , `artifactId` e `version`\n"
+"( `groupId='org.acme'` , `artifactId='code-with-quarkus'` e `version='1.0.0-SNAPSHOT'` )."
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The emojis shown above may not match precisely. The appearance of emojis can vary with the font used or the terminal/environment. IntelliJ IDEA, for example, has several long-running issues open regarding the behavior/rendering of emojis in the terminal."
 msgstr "Os emojis mostrados acima podem não corresponder exatamente. A aparência dos emojis pode variar de acordo com a fonte usada ou com o terminal/ambiente. O IntelliJ IDEA, por exemplo, tem vários problemas de longa data em aberto com relação ao comportamento/renderização de emojis no terminal."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "You can specify the `groupId`, `artifactId` and `version` using the `group:artifactId:version` coordinates syntax directly from the command line.\n"
 "You can selectively omit segments to use the default values:"
-msgstr "O senhor pode especificar `groupId` , `artifactId` e `version` usando a sintaxe de coordenadas `group:artifactId:version` diretamente da linha de comando. O senhor pode omitir seletivamente os segmentos para usar os valores padrão:"
+msgstr "Você pode especificar `groupId` , `artifactId` e `version` usando a sintaxe de coordenadas `group:artifactId:version` diretamente da linha de comando. Você pode omitir segmentos seletivamente para usar os valores padrão:"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The output will show your project being created:"
-msgstr "O resultado mostrará que o projeto está sendo criado:"
+msgstr "A saída mostrará seu projeto sendo criado:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Use the `--help` option to display the options for creating projects:"
 msgstr "Use a opção `--help` para exibir as opções de criação de projetos:"
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Specifying the Quarkus version"
 msgstr "Especificando a versão do Quarkus"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Both `quarkus create` and `quarkus extension list` allow you to explicitly specify a version of Quarkus in one of two ways:"
-msgstr "Both `quarkus create` and `quarkus extension list` allow you to explicitly specify a version of Quarkus in one of two ways:"
+msgstr "Tanto `quarkus create` quanto `quarkus extension list` permitem que você especifique explicitamente uma versão do Quarkus de duas maneiras:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Specify a specific Platform Release BOM"
-msgstr "Especificar uma lista técnica de lançamento de plataforma específica"
+msgstr "Forneça um Platform Release BOM específico"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "A xref:platform.adoc#quarkus-platform-bom[Quarkus Platform release BOM] is identified by `groupId:artifactId:version` (GAV) coordinates. When specifying a platform release BOM, you may use empty segments to fall back to default values (shown with `quarkus create app --help`). If you specify only one segment (no `:`), it is assumed to be a version."
-msgstr "Uma lista xref:platform.adoc#quarkus-platform-bom[técnica de lançamento da plataforma Quarkus] é identificada pelas coordenadas `groupId:artifactId:version` (GAV). Ao especificar uma lista técnica de lançamento da plataforma, o senhor pode usar segmentos vazios para voltar aos valores padrão (mostrados com `quarkus create app --help` ). Se o senhor especificar apenas um segmento (sem `:` ), ele será considerado uma versão."
+msgstr "Um xref:platform.adoc#quarkus-platform-bom[Quarkus Platform Release BOM] é identificado pelas coordenadas `groupId:artifactId:version` (GAV). Quando especificado um platform release BOM, você pode usar segmentos vazios para usar os valores padrões (mostrados com `quarkus create app --help`). Se você especificar apenas um segmento (sem `:`), ele será considerado uma versão."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "`{quarkus-platform-groupid}` is the default `groupId`. Specifying `-P :quarkus-bom:` is equivalent to `-P {quarkus-platform-groupid}:quarkus-bom:{quarkus-version}`. Note that you need to specify the `groupId` to work with a snapshot, e.g. `-P io.quarkus::999-SNAPSHOT` is equivalent to `-P io.quarkus:quarkus-bom:999-SNAPSHOT`."
-msgstr "`{quarkus-platform-groupid}` é o padrão `groupId` . Especificar `-P :quarkus-bom:` é equivalente a `-P {quarkus-platform-groupid}:quarkus-bom:{quarkus-version}` . Observe que o senhor precisa especificar o `groupId` para trabalhar com um instantâneo, por exemplo, `-P io.quarkus::999-SNAPSHOT` é equivalente a `-P io.quarkus:quarkus-bom:999-SNAPSHOT` ."
+msgstr "`{quarkus-platform-groupid}` é o `groupId` padrão. Especificando `-P :quarkus-bom:` é equivalente a `-P {quarkus-platform-groupid}:quarkus-bom:{quarkus-version}`. Note que é necessário especificar o `groupId` para trabalhar com um snapshot, por exemplo, `-P io.quarkus::999-SNAPSHOT` é equivalente a `-P io.quarkus:quarkus-bom:999-SNAPSHOT`."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Default values are subject to change. Use the `--dry-run` option to see the computed value."
-msgstr "Os valores padrão estão sujeitos a alterações. Use a opção `--dry-run` para ver o valor calculado."
+msgstr "Os valores padrão estão sujeitos a alterações. Use a opção `--dry-run` para ver o valor computado."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Specify a Platform Stream"
-msgstr "Especificar um fluxo de plataforma"
+msgstr "Forneça um Plataform Stream"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "A platform stream operates against a remote registry. Each registry defines one or more platform streams, and each stream defines one or more platform release BOM files that define how projects using that stream should be configured."
-msgstr "Um fluxo de plataforma opera em relação a um registro remoto. Cada registro define um ou mais fluxos de plataforma, e cada fluxo define um ou mais arquivos de lista técnica de versão de plataforma que definem como os projetos que usam esse fluxo devem ser configurados."
+msgstr "Um platform stream opera em um registro remoto. Cada registro define um ou mais platform stream, e cada fluxo define um ou mais arquivos do platform release BOM que definem como os projetos que usam esse fluxo devem ser configurados."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Streams are identified using `platformKey:streamId` syntax. A specific stream can be specified using `-S platformKey:streamId`. When specifying a stream, empty segments will be replaced with _discovered_ defaults, based on stream resource resolution rules."
-msgstr "Os fluxos são identificados usando a sintaxe `platformKey:streamId` . Um fluxo específico pode ser especificado usando `-S platformKey:streamId` . Ao especificar um fluxo, os segmentos vazios serão substituídos por padrões _descobertos_ , com base nas regras de resolução de recursos de fluxo."
+msgstr "Streams são identificados usando a sintaxe `platformKey:streamId`. Um stream específico pode ser especificado usando `-S platformKey:streamId`. Ao especificar um stream, os segmentos vazios serão substituídos por valores padrões descobertos, com base nas regras de resolução de recursos stream."
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Working with extensions"
 msgstr "Trabalhando com extensões"
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Listing extensions"
-msgstr "Extensões de listagem"
+msgstr "Listando extensões"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "The Quarkus CLI can be used to list Quarkus extensions."
-msgstr "The Quarkus CLI can be used to list Quarkus extensions."
+msgstr "O Quarkus CLI pode ser usado para listar as extensões do Quarkus."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The format of the result can be controlled with one of four options:"
 msgstr "O formato do resultado pode ser controlado com uma das quatro opções:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "`--name`    Display the name (artifactId) only"
 msgstr "`--name` Exibir apenas o nome (artifactId)"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "`--concise` Display the name (artifactId) and description"
 msgstr "`--concise` Exibir o nome (artifactId) e a descrição"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "`--full`    Display concise format and version/status-related columns."
-msgstr "`--full` Exibir formato conciso e colunas relacionadas à versão/status."
+msgstr "`--full` Exibe o formato conciso e as colunas relacionadas à versão/status."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "`--origins` Display concise information along with the Quarkus platform release origin of the extension."
-msgstr "`--origins` Exibir informações concisas junto com a origem da versão da plataforma Quarkus da extensão."
+msgstr "`--origins` Exibe informação concisa segundo a origem da extensão na plataforma Quarkus."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The behavior of `quarkus ext ls` will vary depending on context."
-msgstr "O comportamento do site `quarkus ext ls` varia de acordo com o contexto."
+msgstr "O comportamento do `quarkus ext ls` varia de acordo com o contexto."
 
 #. type: Title =====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Listing extensions for a Quarkus release"
-msgstr "Listagem de extensões para uma versão do Quarkus"
+msgstr "Listando extensões para uma versão do Quarkus"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "If you invoke the Quarkus CLI from outside of a project, Quarkus will list all the extensions available for the Quarkus release used by the CLI itself."
-msgstr "If you invoke the Quarkus CLI from outside of a project, Quarkus will list all the extensions available for the Quarkus release used by the CLI itself."
+msgstr "Se você executar o Quarkus CLI de fora de um projeto, o Quarkus listará todas as extensões disponíveis para a versão do Quarkus usada pelo próprio CLI."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "You can also list extensions for a specific release of Quarkus using `-P` or `-S`, as described in <<specifying-quarkus-version>>."
-msgstr "O senhor também pode listar as extensões de uma versão específica do Quarkus usando `-P` ou `-S` , conforme descrito em <<specifying-quarkus-version>> ."
+msgstr "Você também pode listar as extensões de uma versão específica do Quarkus usando `-P` ou `-S` , conforme descrito em <<specifying-quarkus-version>> ."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "This mode uses the `--origins` format by default."
-msgstr "This mode uses the `--origins` format by default."
+msgstr "Este modo usa o formato `--origins` por padrão."
 
 #. type: Title =====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Listing extensions for a Quarkus project"
 msgstr "Listando extensões para um projeto Quarkus"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "When working with a Quarkus project, the CLI will list the extensions the current project has installed, using the `--name` format by default."
-msgstr "When working with a Quarkus project, the CLI will list the extensions the current project has installed, using the `--name` format by default."
+msgstr "Ao trabalhar com um projeto Quarkus, o CLI listará as extensões que o projeto atual tem instalado, usando o formato `--name` por padrão."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Use the `--installable` or `-i` option to list extensions that can be installed from the Quarkus platform the project is using."
-msgstr "Use the `--installable` or `-i` option to list extensions that can be installed from the Quarkus platform the project is using."
+msgstr "Use a opção `--installable` ou `-i` para listar as extensões que podem ser instaladas a partir da plataforma Quarkus que o projeto está usando."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "You can narrow or filter the list using search (`--search` or `-s`)."
-msgstr "You can narrow or filter the list using search (`--search` or `-s`)."
+msgstr "Você pode limitar ou filtrar a lista utilizando a pesquisa (`--search` or `-s`)."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Adding extensions"
-msgstr "Adição de extensões"
+msgstr "Adicionando extensões"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "The Quarkus CLI can add one or more extensions to your project with the `add`\n"
 "subcommand:"
-msgstr "A CLI do Quarkus pode adicionar uma ou mais extensões ao seu projeto com o subcomando `add` :"
+msgstr "O Quarkus CLI pode adicionar uma ou mais extensões ao seu projeto com o subcomando `add`:"
 
 #: _guides/cli-tooling.adoc
 #, fuzzy
 msgid "You can install all extensions which match a glob pattern:"
-msgstr "O senhor pode instalar todas as extensões que correspondem a um padrão glob:"
+msgstr "Você pode instalar todas as extensões que correspondem a um glob pattern:"
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Removing extensions"
-msgstr "Remoção de extensões"
+msgstr "Removendo extensões"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "The Quarkus CLI can remove one or more extensions from your project with the `remove`/`rm`\n"
 "subcommand:"
-msgstr "A CLI do Quarkus pode remover uma ou mais extensões do seu projeto com o subcomando `remove` / `rm` :"
+msgstr "O Quarkus CLI pode remover uma ou mais extensões do seu projeto com o subcomando `remove`/ `rm`:"
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
 #, fuzzy, no-wrap
 msgid "Build your project"
-msgstr "Crie seu projeto"
+msgstr "Compile seu projeto"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "To build your project using the Quarkus CLI (using the default configuration in this example),\n"
 "use the `build` command:"
-msgstr "Para criar seu projeto usando a CLI do Quarkus (usando a configuração padrão neste exemplo), use o comando `build` :"
+msgstr ""
+"Para compilar seu projeto usando o Quarkus CLI (usando a configuração padrão neste exemplo),\n"
+"use o comando `build`:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Output will vary depending on the build tool your project is using (Maven, Gradle, or JBang)."
-msgstr "A saída varia de acordo com a ferramenta de compilação que o projeto está usando (Maven, Gradle ou JBang)."
+msgstr "A saída varia de acordo com a ferramenta de compilação que seu projeto está usando (Maven, Gradle ou JBang)."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Run `quarkus build --clean` to perform clean as part of the build."
-msgstr "Execute `quarkus build --clean` para realizar a limpeza como parte da compilação."
+msgstr "Execute `quarkus build --clean` para efetuar a limpeza como parte da compilação."
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Development mode"
 msgstr "Modo de desenvolvimento"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "To start dev mode from the Quarkus CLI, use the `dev` command:"
-msgstr "To start dev mode from the Quarkus CLI, use the `dev` command:"
+msgstr "Para iniciar o modo de desenvolvimento a partir do Quarkus CLI, utilize o comando `dev`:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Run `quarkus dev --clean` to perform clean as part of the build."
-msgstr "Execute `quarkus dev --clean` para realizar a limpeza como parte da compilação."
+msgstr "Execute `quarkus build --clean` para efetuar a limpeza como parte da compilação."
 
 #. type: Title ==
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Shell autocomplete and aliases"
-msgstr "Autocompletar e aliases do shell"
+msgstr "Autocompletar e atalhos do terminal"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Automatic command completion is available for Bash and Zsh:"
-msgstr "Automatic command completion is available for Bash and Zsh:"
+msgstr "O preenchimento automático de comandos está disponível para o Bash e o Zsh:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "If you choose to use an alias for the `quarkus` command, adjust the command completion with the following commands:"
-msgstr "Se o senhor optar por usar um alias para o comando `quarkus` , ajuste a conclusão do comando com os seguintes comandos:"
+msgstr "Se você optar por usar um atalho (alias) para o comando `quarkus`, ajuste a terminação do comando da seguinte forma:"
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Container images"
-msgstr "Imagens de contentores"
+msgstr "Imagens de Contêiner"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "The Quarkus CLI allows building container images without tampering with your project configuration (adding / removing container image extensions).\n"
 "To build the image for your project:"
-msgstr "A CLI do Quarkus permite criar imagens de contêineres sem alterar a configuração do projeto (adicionar/remover extensões de imagens de contêineres). Para criar a imagem para seu projeto:"
+msgstr ""
+"A CLI do Quarkus permite criar imagens de containers sem interferir na configuração do projeto (adicionar/remover extensões de imagens de containers).\n"
+"Para criar a imagem do seu projeto:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The `image build` command can be used directly, or a subcommand can be selected. The available subcommands are:"
-msgstr "O comando `image build` pode ser usado diretamente ou um subcomando pode ser selecionado. Os subcomandos disponíveis são:"
+msgstr "O comando `image build` pode ser usado diretamente ou um subcomando pode ser adicionado. Os subcomandos disponíveis são:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "docker"
-msgstr "doca"
+msgstr "docker"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "buildpacks"
-msgstr "pacotes de compilação"
+msgstr "buildpacks"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "jib"
 msgstr "jib"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "openshift"
 msgstr "openshift"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Each subcommand corresponds to an image building tool supported by Quarkus and gives access to specific configuration options."
 msgstr "Cada subcomando corresponde a uma ferramenta de criação de imagens compatível com o Quarkus e dá acesso a opções de configuração específicas."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "For example, to use a https://buildpacks.io/[Cloud Native Buildpack] with a custom builder image, use the following:"
-msgstr "Por exemplo, para usar um link:https://buildpacks.io/[Cloud Native Buildpack] com uma imagem de construtor personalizada, use o seguinte:"
+msgstr "Por exemplo, para usar um link:https://buildpacks.io/[Cloud Native Buildpack] com uma imagem personalizada, use o seguinte:"
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Pushing"
-msgstr "Empurrando"
+msgstr "Transmitindo"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "The `image push` command is similar to `image build`, and surfaces some basic options required to push images to a target container registry."
-msgstr "The `image push` command is similar to `image build`, and surfaces some basic options required to push images to a target container registry."
+msgstr "O comando `image push` é semelhante ao `image build` e apresenta algumas opções básicas necessárias para enviar imagens para um registro de contêiner alvo."
 
 #. type: Title ==
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Extending the CLI"
-msgstr "Ampliação da CLI"
+msgstr "Ampliando o CLI"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "The Quarkus CLI embeds a plugin system that can be used to dynamically add commands and subcommands to the CLI."
-msgstr "The Quarkus CLI embeds a plugin system that can be used to dynamically add commands and subcommands to the CLI."
+msgstr "O Quarkus CLI incorpora um sistema de plugins que pode ser usado para adicionar dinamicamente comandos e subcomandos ao CLI."
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "What is a plugin"
 msgstr "O que é um plugin"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "A plugin can be any executable, jar or Java command that can be found locally or obtained remotely."
-msgstr "A plugin can be any executable, jar or Java command that can be found locally or obtained remotely."
+msgstr "Um plugin pode ser qualquer executável, jar ou comando Java que possa ser encontrado localmente ou obtido remotamente."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Plugins are classified as follows:"
-msgstr "Plugins are classified as follows:"
+msgstr "Os plugins são classificados da seguinte forma:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Plugins executed via shell"
-msgstr "Plug-ins executados via shell"
+msgstr "Plugins executados via terminal"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "*executable* (any executable prefixed with `quarkus-` found locally)"
-msgstr "*executável* (qualquer executável prefixado com `quarkus-` encontrado localmente)"
+msgstr "*executável* (qualquer executável precedido de `quarkus-` encontrado localmente)"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Plugins executed via jbang"
-msgstr "Plug-ins executados via jbang"
+msgstr "Plugins executados via jbang"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "*jar* (any runnable jar found locally)"
-msgstr "*jar* (qualquer jar executável encontrado localmente)"
+msgstr "*jar* (qualquer executável jar encontrado localmente)"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "*jbang alias* (any jbang alias prefixed with `quarkus-` installed locally or through the quarkusio catalog)"
-msgstr "*alias de jbang* (qualquer alias de jbang prefixado com `quarkus-` instalado localmente ou por meio do catálogo do quarkusio)"
+msgstr "*jbang alias* (qualquer atalho jbang precedido de `quarkus-` instalado localmente ou via catálogo quarkusio)"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "*maven* (any maven coordinate in GACTV form pointing to a runnable jar)"
 msgstr "*maven* (qualquer coordenada maven no formato GACTV apontando para um jar executável)"
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "How to obtain plugins"
-msgstr "Como obter plug-ins"
+msgstr "Como obter plugins"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Plugins can be found via multiple sources that are described below."
-msgstr "Plugins can be found via multiple sources that are described below."
+msgstr "Os plugins podem ser encontrados em várias fontes, descritas a seguir."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Extensions"
 msgstr "Extensões"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "A Quarkus extension may define a list of `cli-plugins` as part of its metadata.\n"
 "The list may contain GACTV string pointing to executable jars."
-msgstr "Uma extensão Quarkus pode definir uma lista de `cli-plugins` como parte de seus metadados. A lista pode conter uma cadeia de caracteres GACTV que aponta para jars executáveis."
+msgstr ""
+"Uma extensão Quarkus pode definir uma lista de `cli-plugins` como parte de seus metadados.\n"
+"A lista pode conter uma cadeia de caracteres GACTV que aponta para jars executáveis."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "At the moment, the CLI is able to obtain the list of available extensions,\n"
 "but is not very accurate on the exact version of the extension (it uses the version found in the extension catalog)."
-msgstr "No momento, a CLI é capaz de obter a lista de extensões disponíveis, mas não é muito precisa quanto à versão exata da extensão (ela usa a versão encontrada no catálogo de extensões)."
+msgstr ""
+"No momento, o CLI pode obter a lista de extensões disponíveis,\n"
+"mas não é muito preciso quanto à versão exata da extensão (ele usa a versão encontrada no catálogo de extensões)."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Local path scanning"
-msgstr "Varredura de caminho local"
+msgstr "Varredura local"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Scan the path elements for executable files prefixed with `quarkus-`."
-msgstr "Scan the path elements for executable files prefixed with `quarkus-`."
+msgstr "Examine os elementos do diretório em busca de arquivos executáveis com o prefixo `quarkus-`."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Using JBang aliases"
-msgstr "Uso de aliases do JBang"
+msgstr "Usando atalhos do JBang"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Scan the local or project jbang catalog for aliases prefixed with `quarkus-`."
-msgstr "Scan the local or project jbang catalog for aliases prefixed with `quarkus-`."
+msgstr "Examina o catálogo jbang local ou do projeto em busca de atalhos precedidos do prefixo `quarkus-`."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Using the JBang quarkusio catalog"
 msgstr "Usando o catálogo JBang do quarkusio"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Scan the `quarkusio` catalog for aliases prefixed with `quarkus-`."
-msgstr "Scan the `quarkusio` catalog for aliases prefixed with `quarkus-`."
+msgstr "Examina o catálogo do `quarkusio` em busca de atalhos precedidos do prefixo `quarkus-`."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Uses the JBang binary. If missing, it will be automatically installed under `.jbang`."
-msgstr "Usa o binário JBang. Se estiver faltando, ele será instalado automaticamente em `.jbang` ."
+msgstr "Usa o binário JBang. Se estiver ausente, ele será instalado automaticamente em `.jbang`."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Explicitly using the plugin commands"
-msgstr "Usando explicitamente os comandos do plug-in"
+msgstr "Usando especificamente os comandos do plugin"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "See `quarkus plugin add` below"
-msgstr "See `quarkus plugin add` below"
+msgstr "Veja `quarkus plugin add` abaixo"
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Managing plugins"
-msgstr "Gerenciando plug-ins"
+msgstr "Gerenciando plugins"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Plugins are managed using the following commands."
-msgstr "Plugins are managed using the following commands."
+msgstr "Os plugins são gerenciados usando os seguintes comandos."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Listing plugins"
-msgstr "Listagem de plugins"
+msgstr "Listando plugins"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "The following command lists the installed plugins:"
-msgstr "The following command lists the installed plugins:"
+msgstr "O comando a seguir lista os plugins instalados:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "To list the available/installable plugins:"
-msgstr "Para listar os plug-ins disponíveis/instaláveis:"
+msgstr "Para listar os plugins disponíveis/instaláveis:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The output of the `list` command may be filtered by `type` using `-t` or by name using `-s` flag and a search pattern."
-msgstr "A saída do comando `list` pode ser filtrada por `type` usando `-t` ou por nome usando o sinalizador `-s` e um padrão de pesquisa."
+msgstr "A saída do comando `list` pode ser filtrada por `tipo` usando `-t` ou por nome usando a flag `-s` e um padrão de pesquisa."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "For instance, to list all the installable plugins starting with the letter `k`, use the following command:"
-msgstr "Por exemplo, para listar todos os plug-ins instaláveis que começam com a letra `k` , use o seguinte comando:"
+msgstr "Por exemplo, para listar todos os plugins instaláveis que começam com a letra `k`, use o seguinte comando:"
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Adding plugins"
-msgstr "Adição de plug-ins"
+msgstr "Adicionando plugins"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "To add any of the installable plugins, use `quarkus plugin add <name or location>`:"
-msgstr "To add any of the installable plugins, use `quarkus plugin add <name or location>`:"
+msgstr "Para adicionar qualquer um dos plugins instaláveis, use `quarkus plugin add <nome ou local>`:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The command above installed a plugin by `name` using the name as listed by `quarkus plugin list --installable`."
-msgstr "O comando acima instalou um plug-in de `name` usando o nome listado por `quarkus plugin list --installable` ."
+msgstr "O comando acima instalou um plugin usando o `name` conforme listado por `quarkus plugin list --installable`."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "The installed command can be now executed using `quarkus kill`."
-msgstr "O comando instalado agora pode ser executado usando `quarkus kill` ."
+msgstr "O comando instalado agora pode ser executado usando o `quarkus kill`."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "Users are not limited to the plugins discovered by `quarkus plug list --installable`.\n"
 "Users may install plugins as long as they provide the URL or the Maven coordinates pointing to an executable jar or Java file."
-msgstr "Os usuários não estão limitados aos plug-ins descobertos por `quarkus plug list --installable` . Os usuários podem instalar plug-ins desde que forneçam o URL ou as coordenadas do Maven apontando para um arquivo jar ou Java executável."
+msgstr ""
+"Os usuários não estão limitados aos plugins encontrados pelo `quarkus plug list --installable`.\n"
+"Os usuários podem instalar plugins desde que forneçam o URL ou as coordenadas Maven que apontem para um arquivo jar ou Java executável."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "You can install an executable jar as a plugin via Maven coordinates."
-msgstr "O senhor pode instalar um jar executável como um plug-in por meio das coordenadas do Maven."
+msgstr "Você pode instalar um jar executável como um plugin via coordenadas Maven."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "For instance, let's use `io.quarkiverse.authzed:quarkus-authzed-cli:runner:jar:0.2.0` which is a real executable jar that provides a CLI utility for the `quarkus-authzed` extension."
-msgstr "Por exemplo, vamos usar o `io.quarkiverse.authzed:quarkus-authzed-cli:runner:jar:0.2.0` , que é um jar executável real que fornece um utilitário CLI para a extensão `quarkus-authzed` ."
+msgstr "Por exemplo, vamos usar `io.quarkiverse.authzed:quarkus-authzed-cli:runner:jar:0.2.0`, que é um jar executável real que fornece um recurso CLI para a extensão `quarkus-authzed`."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "It is also possible to set a description that will appear in the help output."
-msgstr "Também é possível definir uma descrição que será exibida na saída da ajuda."
+msgstr "É possível também definir uma descrição que será exibida na saída do `help`."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Where are the plugins added?"
-msgstr "Onde os plug-ins são adicionados?"
+msgstr "Onde os plugins são instalados?"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Plugins are added in the plugin catalog that lives at: `<user home>/.quarkus/cli/plugins/quarkus-cli-catalog.json`."
-msgstr "Plugins are added in the plugin catalog that lives at: `<user home>/.quarkus/cli/plugins/quarkus-cli-catalog.json`."
+msgstr "Os plugins são inseridos no catálogo de plugins que fica em: `<user home>/.quarkus/cli/plugins/quarkus-cli-catalog.json`."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "There is a second plugin catalog that is relative to the current project (if available): `<project root>/.quarkus/cli/plugins/quarkus-cli-catalog.json`."
-msgstr "There is a second plugin catalog that is relative to the current project (if available): `<project root>/.quarkus/cli/plugins/quarkus-cli-catalog.json`."
+msgstr "Há um segundo catálogo de plugins que é relativo ao projeto atual (se disponível): `<raiz do projeto>/.quarkus/cli/plugins/quarkus-cli-catalog.json`."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "The effective catalog is the combination of both the `user` and `project` catalogs with the latter being able to override entries of the former (e.g. use a different version or location for a plugin)."
-msgstr "The effective catalog is the combination of both the `user` and `project` catalogs with the latter being able to override entries of the former (e.g. use a different version or location for a plugin)."
+msgstr "O catálogo efetivo é a combinação dos catálogos do `usuário` e do `projeto`, sendo que o último pode substituir entradas do primeiro (por exemplo, usar uma versão ou um local diferente para um plugin)."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "If the project catalog is available, it will always be preferred, unless explicitly specified with the `--user` flag."
-msgstr "If the project catalog is available, it will always be preferred, unless explicitly specified with the `--user` flag."
+msgstr "Se o catálogo do projeto estiver disponível, ele sempre terá preferência, a menos que seja explicitamente especificado com o sinalizador `--user`."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "The column `scope` of the plugins table indicates where the plugin is/will be added."
-msgstr "The column `scope` of the plugins table indicates where the plugin is/will be added."
+msgstr "A coluna `scope` da tabela de plugins indica onde o plugin está/será adicionado."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Removing plugins"
-msgstr "Remoção de plug-ins"
+msgstr "Removendo plugins"
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "Plugins are removed using `quarkus plugin remove <plugin name>`."
-msgstr "Plugins are removed using `quarkus plugin remove <plugin name>`."
+msgstr "Os plugins são removidos usando `quarkus plugin remove <nome do plugin>`."
 
 #. type: Title ====
 #: _guides/cli-tooling.adoc
-#, fuzzy, no-wrap
+
 msgid "Syncing plugins"
-msgstr "Plug-ins de sincronização"
+msgstr "Sincronizando plugins"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid ""
 "To remove stale plugins or discover new plugins provided by extensions, the `quarkus plugin sync` command is available.\n"
 "With this command binaries and JBang aliases that are added to the catalog but are no longer available will be purged."
-msgstr "Para remover plug-ins obsoletos ou descobrir novos plug-ins fornecidos por extensões, o comando `quarkus plugin sync` está disponível. Com esse comando, os binários e os aliases JBang adicionados ao catálogo, mas que não estão mais disponíveis, serão eliminados."
+msgstr ""
+"Para remover plugins obsoletos ou descobrir novos plugins fornecidos por extensões, está disponível o comando `quarkus plugin sync`.\n"
+"Com este comando, os binários e atalhos do JBang adicionados ao catálogo, mas que não estão mais disponíveis, serão eliminados."
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Remote plugins that are explicitly added by the user using URL/Maven coordinates are excluded from the removal."
-msgstr "Os plug-ins remotos que são explicitamente adicionados pelo usuário usando coordenadas de URL/Maven são excluídos da remoção."
+msgstr "Os plugins remotos que são explicitamente adicionados pelo usuário usando URL/coordenadas Maven são excluídos da remoção."
 
 #. type: delimited block -
 #: _guides/cli-tooling.adoc
 msgid "The command is also executed implicitly through any of the CLI commands:"
-msgstr "The command is also executed implicitly through any of the CLI commands:"
+msgstr "O comando também é executado implicitamente por meio de qualquer um dos comandos do CLI:"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Weekly"
-msgstr "Semanal"
+msgstr "Semanalmente"
 
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "If the project files have been updated since the last catalog update (limited to the module)."
 msgstr "Se os arquivos do projeto tiverem sido atualizados desde a última atualização do catálogo (limitado ao módulo)."


### PR DESCRIPTION
Here is the translation for the file: cli-tooling.adoc.po (https://quarkus.io/guides/cli-tooling#shell-autocomplete-and-aliases)

- Fixes #181