### PR TITLE
Adjust site preview script

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,14 +32,34 @@ jobs:
         run: |
           bin/setup-build-env-on-ubuntu
 
+      - name: Restore mtime
+        # git restore-mtime is currently broken in the GH Actions images so using our own updated local copy
+        # see https://github.com/MestreLion/git-tools/blob/main/git-restore-mtime
+        run: |
+          cd upstream
+          ./tools/git-restore-mtime
+
       - name: Build for preview
         # Build for preview to build a localized site (only latest guides are built)
         run: vendor/quarkus-l10n-utils/bin/build-for-preview
+
+      # ref. https://github.com/quarkusio/quarkusio.github.io/blob/f935cd0d21acff6e7de9b7c8b6f86622f1104251/.github/workflows/build.yml#L73-L78
+      - name: Reduce the size of the website to be compatible with surge
+        run: |
+          cd upstream
+          find assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf ../docs/{} \;
+          find newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf ../docs/{} \;
+          rm -rf ../docs/assets/stickers
+          rm -rf ../docs/assets/images/worldtour/2023
+          rm -rf ../docs/assets/images/worldtour/2024
+          rm -rf ../docs/assets/images/desktopwallpapers
+          rm -rf ../docs/assets/images/stickers
+
       - name: Deploy to surge
         # Deploy the site to surge.sh
         # We use surge.sh for pull-request preview because surge.sh supports custom sub-domain and it fits pull-request preview site.
         run: |
-          surge docs pr-preview-"${{ github.event.pull_request.number }}"-pt-quarkusio.surge.sh
+          surge docs pr-preview-${{ github.event.pull_request.number }}-pt-quarkusio.surge.sh
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
to reduce the size of the site artifacts; otherwise, surge.sh rejects the upload.

This workflow specifies `pull_request_target` for security reasons, so it only takes effect after it has been merged into `main`.
In other words, this change does not apply to this pull request itself, so it is expected that the checks for this pull request fail.
The fact that preview site deployment for pull requests has succeeded on ja.quarkus.io, where this change has already been applied, demonstrates that this change is valid.
https://github.com/quarkusio/ja.quarkus.io/pull/1139
