### PR TITLE
fix: fuzzy home page

### DIFF
--- a/l10n/po/pt_BR/_includes/homepage-features-icon-band.html.po
+++ b/l10n/po/pt_BR/_includes/homepage-features-icon-band.html.po
@@ -18,7 +18,6 @@ msgstr ""
 
 #. type: Content of: <div><div><div><h2>
 #: upstream/_includes/homepage-features-icon-band.html:4
-#, fuzzy
 msgid "Quarkus Benefits"
 msgstr "Benefícios do Quarkus"
 
@@ -34,13 +33,11 @@ msgstr "Uma plataforma coesa para otimizar a alegria do desenvolvedor com config
 
 #. type: Content of: <div><div><div><img><img><h3>
 #: upstream/_includes/homepage-features-icon-band.html:17
-#, fuzzy
 msgid "<a href=\"/performance\">Performance</a>"
 msgstr "<a href=\"/performance\">Desempenho</a>"
 
 #. type: Content of: <div><div><div><img><img><p>
 #: upstream/_includes/homepage-features-icon-band.html:18
-#, fuzzy
 msgid "Quarkus streamlines framework optimizations in the build phase to reduce runtime dependencies and improve efficiency. By precomputing metadata and optimizing class loading, it ensures fast startup times for JVM and native binary deployments, cutting down on memory usage."
 msgstr "O Quarkus simplifica as otimizações da estrutura na fase de construção para reduzir as dependências do tempo de execução e aumentar a eficiência. Ao pré-computar metadados e otimizar o carregamento de classes, ele garante tempos de inicialização rápidos para implementações de JVM e binários nativos, reduzindo o uso de memória."
 
@@ -66,13 +63,11 @@ msgstr "O Quarkus fornece uma estrutura full-stack coesa e divertida de usar, ap
 
 #. type: Content of: <div><div><div><img><img><h3>
 #: upstream/_includes/homepage-features-icon-band.html:35
-#, fuzzy
 msgid "<a href=\"/continuum\">Reactive Core</a>"
 msgstr "<a href=\"/continuum\">Núcleo reativo</a>"
 
 #. type: Content of: <div><div><div><img><img><p>
 #: upstream/_includes/homepage-features-icon-band.html:36
-#, fuzzy
 msgid "Built on a robust reactive core, Quarkus ensures fast and efficient performance, supporting the development of a wide variety of modern applications."
 msgstr "Criado com base em um núcleo reativo robusto, o Quarkus garante um desempenho rápido e eficiente, oferecendo suporte ao desenvolvimento de uma ampla variedade de aplicativos modernos."
 


### PR DESCRIPTION
This is a draft to test the preview and fix the part that blocks the Portuguese (Brazil) translation.
preview:
<img width="1213" height="609" alt="previewpt1-br" src="https://github.com/user-attachments/assets/91200267-e2f4-4b5a-ac55-6ff9fa9f16be" />

<img width="1136" height="591" alt="previewpt2" src="https://github.com/user-attachments/assets/717d4fa6-95e7-48cb-aa20-b080730a6621" />

site: https://pt.quarkus.io/

<img width="359" height="444" alt="2" src="https://github.com/user-attachments/assets/8ec372f2-451c-466d-b0f0-d8286d307545" />
<img width="337" height="505" alt="1" src="https://github.com/user-attachments/assets/e352aaab-9e1c-4315-ac8a-08d805dadf14" />



