### PR TITLE
docs: improve contributor onboarding with CONTRIBUTING.md and fix translation guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to pt.quarkus.io
+
+This repository contains the Portuguese localization of [quarkus.io](https://quarkus.io).
+
+## Quick Start
+
+1. **Clone** this repository locally:
+
+```bash
+git clone https://github.com/quarkusio/pt.quarkus.io.git
+cd pt.quarkus.io
+```
+
+2. **Fork** this repository on GitHub
+
+3. **Configure push** to your fork:
+
+```bash
+git remote set-url --push origin https://github.com/your-username/pt.quarkus.io.git
+```
+
+4. **Create a branch** for your contribution following conventional branch naming (`<type>/<description>`):
+
+```bash
+git checkout -b docs/translate-mutiny-primer
+```
+
+## Where to Contribute
+
+Translation files are in `l10n/po/pt_BR/`:
+
+- **`_guides/`** — Main guides
+- **`_posts/`** — Blog posts
+
+### Current Priority: Review Existing Translations
+
+The **top priority** is reviewing and improving already-translated guides. Focus on removing "fuzzy" marks, correcting auto-translations, and improving fluency.
+
+Check the translation status to find what needs work:
+
+| Category | Status File |
+|----------|-------------|
+| Main guides | [latest-guides-translation.csv](l10n/stats/latest-guides-translation.csv) |
+| Blog posts | [posts-translation.csv](l10n/stats/posts-translation.csv) |
+| Misc (includes, data) | [misc-translation.csv](l10n/stats/misc-translation.csv) |
+
+## Workflow
+
+1. Create a **GitHub issue** indicating which file you want to translate or review (avoids duplication)
+2. Create a branch with a descriptive name: `docs/translate-filename`
+3. Edit the corresponding `.po` files using tools like [POEdit](https://poedit.net/)
+4. Commit with a clear message using the `docs:` prefix:
+
+```bash
+git commit -m "docs: translate mutiny-primer.adoc.po"
+```
+
+5. **Squash** into a single commit before the PR
+6. Open a **Pull Request** targeting the `main` branch
+
+> **Note:** The site is built automatically on PRs, and a preview link is added to the PR in ~5 minutes.
+
+## Need More Details?
+
+See the full [Translation Guide](translation-guide.pt.md) (in Portuguese) for:
+- How text extraction works with po4a
+- Auto-translation and fuzzy review process
+- Override files and HTML templates
+- Complete contribution workflow

--- a/translation-guide.pt.md
+++ b/translation-guide.pt.md
@@ -13,13 +13,16 @@ O texto extraído é armazenado no [diretório l10n](l10n) como um arquivo .po, 
 ## Contribuindo com a tradução
 
 Se você quiser contribuir com a tradução, clone este repositório localmente, edite o arquivo .po no [diretório l10n](l10n) e envie um Pull-Request.
-Você pode verificar o status da tradução de cada arquivo [aqui](l10n/stats/translation.csv).
+Você pode verificar o status da tradução de cada arquivo nos seguintes relatórios:
+- **Guias principais**: [latest-guides-translation.csv](l10n/stats/latest-guides-translation.csv)
+- **Posts do blog**: [posts-translation.csv](l10n/stats/posts-translation.csv)
+- **Arquivos diversos**: [misc-translation.csv](l10n/stats/misc-translation.csv)
 
 ## Declaração para iniciar a tradução
 
 Para evitar inconvenientes, como vários membros trabalhando no mesmo arquivo ao mesmo tempo ou duplicação de trabalho.
-Indique em qual arquivo e intervalo você deseja começar a trabalhar com um problema do GitHub.
-Por outro lado, ao criar uma issue no GitHub, verifique se alguém já iniciou trabalho no destino de um problema existente no GitHub.
+Indique em qual arquivo e intervalo você deseja começar a trabalhar criando uma **issue** no GitHub.
+Por outro lado, ao criar uma issue no GitHub, verifique se alguém já iniciou o trabalho no destino de uma issue existente.
 
 ### Trabalho de tradução
 


### PR DESCRIPTION
## What

This PR adds a `CONTRIBUTING.md` file to make onboarding easier for new contributors, and fixes outdated references in the Portuguese translation guide.

## Why

- The translation guide referenced `l10n/stats/translation.csv`, which has not been updated since Nov 2023. The stats scripts now generate separate files per category (`latest-guides`, `posts`, `misc`).
- The translation guide used "problema" for GitHub issues, which is confusing since GitHub uses "issue" in its Portuguese UI.
- New contributors need a quick entry point before reading the full translation guide.

## Changes

### New: CONTRIBUTING.md
A TL;DR entry point that points to the translation guide for more details.

### Fixed: translation-guide.pt.md
- Updated status file references to the correct category-specific files
- Changed "problema do GitHub" to "issue" (correct GitHub terminology)

---

@gastaldi PTAL when you have a moment!