### PR TITLE
Bump tsuji to v0.8.20 and optimize config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ out/
 
 ### Local Configuration ###
 .env
-/config/application.local.properties
-/config/application-local.yaml
-/config/application-local.properties
+/config/application.local.yaml
 # Local Claude Code instructions
 CLAUDE.local.md

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -1,8 +1,12 @@
+quarkus:
+  config:
+    locations: config/application.local.yaml
+
 tsuji:
-  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.8.16/tsuji.jar
+  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.8.20/tsuji.jar
 
   language:
-    from: en
+    from: en-US
     to: pt-BR
 
   po:
@@ -10,6 +14,10 @@ tsuji:
 
   translator:
     type: deepl
+
+    language:
+      source: en
+      target: pt-BR
 
     target-directories:
       - _guides
@@ -31,7 +39,6 @@ tsuji:
     extract:
       yaml:
         exclude:
-          - _data/versioned/3-0/index/quarkus.yaml
           - _data/authors.yaml
           - _data/languages.yaml
           - _data/publications.yaml
@@ -40,22 +47,28 @@ tsuji:
       html:
         include:
           - _includes/about.html
-          - _includes/awards-band.html
+          - _includes/ai-blueprints.html
+          - _includes/ai-chainofthought.html
+          - _includes/ai-contextualrag.html
+          - _includes/ai-frozenrag.html
+          - _includes/ai-java-for-ai.html
+          - _includes/ai-overview.html
+          - _includes/ai-quarkus-for-ai.html
+          - _includes/benefactors.html
           - _includes/catalog-detail-band.html
           - _includes/catalog-index-band.html
-          - _includes/community-contrib-band.html
+          - _includes/CF-footerband.html
           - _includes/container-first.html
-          - _includes/continuum.html
           - _includes/developer-joy.html
-          # - _includes/discussion.html  # Temporarily excluded due to malformed HTML (upstream issue)
+          - _includes/discussion.html
           - _includes/events-discussions-band.html
-          - _includes/events-worldtour-band.html
           - _includes/feedback-community-band.html
           - _includes/get-started-band.html
           - _includes/get-started-band-lightblue.html
           - _includes/get-started-code-steps.html
           - _includes/header-navigation.html
-          - _includes/header-navigation_full.html
+          - _includes/homepage-ai-band.html
+          - _includes/homepage-commonhaus-band.html
           - _includes/homepage-container_first-band.html
           - _includes/homepage-developer_joy-band.html
           - _includes/homepage-extensions-band.html
@@ -63,15 +76,27 @@ tsuji:
           - _includes/homepage-features-icon-band.html
           - _includes/homepage-hero-band.html
           - _includes/homepage-hero-band-ssjprime.html
-          - _includes/homepage-hero-Q2release-band.html
           - _includes/homepage-hero-newrelease-band.html
           - _includes/homepage-imperative_and_reactive-band.html
           - _includes/homepage-performance-band.html
+          - _includes/homepage-userstory-callout.html
           - _includes/homepage-worldtour-band.html
+          - _includes/insights-band.html
           - _includes/kubernetes-native.html
+          - _includes/newsletter-band.html
+          - _includes/performance.html
+          - _includes/project-footer.html
+          - _includes/publication-entries.html
+          - _includes/spring-features-band.html
+          - _includes/spring-migrate-books.html
+          - _includes/spring-migrate-main.html
+          - _includes/spring-userstory-callout.html
           - _includes/standards.html
           - _includes/support-help-band.html
           - _includes/support-options-band.html
+          - _includes/training-band.html
+          - _includes/userstories-band.html
+          - _includes/working-group-band.html
           - _includes/worldtour-abstracts.html
           - _includes/worldtour-code.html
           - _layouts/quarkus3.html


### PR DESCRIPTION
- Bump tsuji to v0.8.20
- Add quarkus.config.locations for local config override
- Fix .gitignore to use config/application.local.yaml
- Fix language.from to en-US
- Add translator.language source/target
- Update HTML include list: add 25 new upstream files, remove 6 stale entries
- Remove non-existent _data/versioned/3-0/index/quarkus.yaml from yaml exclude
- Add dependabot.yml for GitHub Actions updates