### PR TITLE
LLM-based Translation Preview for Portuguese (pt-BR)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Build
-        run: ./tsujiw jekyll build --accept-mt=gemini
+        run: ./tsujiw jekyll build
 
       - name: Deploy to GitHub Pages
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,7 +60,7 @@ jobs:
           ./tools/git-restore-mtime
 
       - name: Build for preview
-        run: ./tsujiw jekyll build --accept-mt=gemini --additional-configs=_only_latest_guides_config.yml
+        run: ./tsujiw jekyll build --additional-configs=_only_latest_guides_config.yml
 
       - name: Reduce the size of the website to be compatible with surge
         run: |

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -9,6 +9,9 @@ tsuji:
     from: en-US
     to: pt-BR
 
+  rag:
+    index-path: l10n/rag/index
+
   po:
     base-dir: l10n/po/pt_BR
 
@@ -27,6 +30,25 @@ tsuji:
       - _includes
       - _layouts
       - _redirects
+
+    gemini:
+      model:
+        model-id: gemini-3-flash-preview
+        thinking:
+          thinking-level: MINIMAL
+      escalation-model:
+        model-id: gemini-3.1-pro-preview
+        thinking:
+          thinking-level: LOW
+      prompts:
+        system-prompt: "config/prompts/translation-system-prompt.txt"
+        asciidoc-markup-rules: "config/prompts/asciidoc-markup-rules.txt"
+
+    openai:
+      prompts:
+        system-prompt: "config/prompts/translation-system-prompt.txt"
+        asciidoc-markup-rules: "config/prompts/asciidoc-markup-rules.txt"
+
 
   jekyll:
     source-dir: upstream

--- a/config/prompts/asciidoc-markup-rules.txt
+++ b/config/prompts/asciidoc-markup-rules.txt
@@ -1,0 +1,4 @@
+- Preserve ALL Asciidoc markup exactly:
+  - Never change: URLs, link/xref/image targets, {attributes}, backslash escapes (\_, \\)
+  - Keep cross-reference anchors (<<...>>) unchanged
+  - In link:URL[text] or xref:ref[text], only translate the text inside []

--- a/config/prompts/html-markup-rules.txt
+++ b/config/prompts/html-markup-rules.txt
@@ -1,0 +1,4 @@
+- Preserve ALL HTML tags exactly:
+  - Keep tags as-is: <strong>, <em>, <code>, <a>, <div>, <span>, etc.
+  - Keep tag attributes unchanged: <a href="...">, <img src="...">
+  - Translate only text content between tags, not the tags themselves

--- a/config/prompts/translation-system-prompt.txt
+++ b/config/prompts/translation-system-prompt.txt
@@ -1,0 +1,23 @@
+You are a professional translator for open-source project documentation.
+Translate the given texts from {srcLang} to {dstLang}.
+
+GLOSSARY:
+{glossary}
+
+INPUT FORMAT:
+You will receive a JSON array of objects. Each object has:
+- "index": The item index (0-based)
+- "text": The text to translate
+- "tm": (Optional) Translation memory array (original-translation pairs) specific to this text
+- "note": (Optional) Additional note specific to this text.
+          Follow this note carefully to ensure translation quality.
+
+RULES:
+- Each input text is ONE unit — do NOT split at newlines
+- Translate only natural language content
+- Maintain terminology consistency within the batch
+- If "tm" field is present, use it as a terminology reference only:
+  - Use consistent terms found in tm, but write natural sentences in your own words
+  - Do NOT copy sentence structure or phrasing from tm
+
+{additional_rules}

--- a/l10n/po/pt_BR/_guides/mailer-reference.adoc.po
+++ b/l10n/po/pt_BR/_guides/mailer-reference.adoc.po
@@ -9,114 +9,132 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: YAML Front Matter: title
 #. This guide is maintained in the main Quarkus repository
 #. and pull requests should be submitted there:
 #. https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+#. type: Title =
+#. mt: gemini
 #: _guides/mailer-reference.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Mailer Reference Guide"
 msgstr "Guia de Referência do Mailer"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "This guide is the companion from the xref:mailer.adoc[Mailer Getting Started Guide].\n"
 "It explains in more details the configuration and usage of the Quarkus Mailer."
-msgstr "Este guia é o complemento do xref:mailer.adoc[Guia de Introdução ao Mailer] . Ele explica em mais detalhes a configuração e o uso do Quarkus Mailer."
+msgstr ""
+"Este guia é o guia complementar do xref:mailer.adoc[Guia de Introdução ao Mailer].\n"
+"Ele explica em mais detalhes a configuração e o uso do Quarkus Mailer."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Mailer extension"
-msgstr "Extensão do Mailer"
+msgstr "Extensão Mailer"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "To use the mailer, you need to add the `quarkus-mailer` extension."
-msgstr "Para usar o mailer, o senhor precisa adicionar a extensão `quarkus-mailer` ."
+msgstr "Para usar o mailer, você precisa adicionar a extensão `quarkus-mailer`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "You can add the extension to your project using:"
-msgstr "O senhor pode adicionar a extensão ao seu projeto usando:"
+msgstr "Você pode adicionar a extensão ao seu projeto usando:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Or just add the following dependency to your project:"
-msgstr "Ou simplesmente adicione a seguinte dependência ao seu projeto:"
+msgstr "Ou apenas adicione a seguinte dependência ao seu projeto:"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Accessing the mailer"
 msgstr "Acessando o mailer"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "You can inject the mailer in your application using:"
-msgstr "O senhor pode injetar o mailer em seu aplicativo usando:"
+msgstr "Você pode injetar o mailer em sua aplicação usando:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "There are 2 APIs:"
 msgstr "Existem 2 APIs:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "`io.quarkus.mailer.Mailer` provides the imperative (blocking and synchronous) API;"
-msgstr "`io.quarkus.mailer.Mailer` fornece a API imperativa (bloqueadora e síncrona);"
+msgstr "`io.quarkus.mailer.Mailer` fornece a API imperativa (bloqueante e síncrona);"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "`io.quarkus.mailer.reactive.ReactiveMailer` provides the reactive (non-blocking and asynchronous) API"
-msgstr "`io.quarkus.mailer.reactive.ReactiveMailer` fornece a API reativa (sem bloqueio e assíncrona)"
+msgstr "`io.quarkus.mailer.reactive.ReactiveMailer` fornece a API reativa (não bloqueante e assíncrona)"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "The two APIs are equivalent feature-wise. Actually the `Mailer` implementation is built on top of the `ReactiveMailer` implementation."
-msgstr "As duas APIs são equivalentes em termos de recursos. Na verdade, a implementação do `Mailer` foi criada com base na implementação do `ReactiveMailer` ."
+msgstr "As duas APIs são equivalentes em termos de funcionalidades. Na verdade, a implementação do `Mailer` é construída sobre a implementação do `ReactiveMailer`."
 
 #. type: Block title
+#. mt: gemini
 #: _guides/mailer-reference.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Deprecation"
 msgstr "Depreciação"
 
-#. type: Plain text
+#. type: delimited block =
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "`io.quarkus.mailer.ReactiveMailer` is deprecated in favor of `io.quarkus.mailer.reactive.ReactiveMailer`."
-msgstr "`io.quarkus.mailer.ReactiveMailer` está obsoleto em favor de `io.quarkus.mailer.reactive.ReactiveMailer` ."
+msgstr "`io.quarkus.mailer.ReactiveMailer` foi depreciada em favor de `io.quarkus.mailer.reactive.ReactiveMailer`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "To send a simple email, proceed as follows:"
 msgstr "Para enviar um e-mail simples, proceda da seguinte forma:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "For example, you can use the `Mailer` in an HTTP endpoint as follows:"
-msgstr "Por exemplo, o senhor pode usar o `Mailer` em um endpoint HTTP da seguinte forma:"
+msgstr "Por exemplo, você pode usar o `Mailer` em um endpoint HTTP da seguinte forma:"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Creating Mail objects"
-msgstr "Criando objetos do Mail"
+msgstr "Criando objetos Mail"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
@@ -124,62 +142,75 @@ msgid ""
 "You can create new `io.quarkus.mailer.Mail` instances from the constructor or from the `Mail.withText` and\n"
 "`Mail.withHtml` helper methods.\n"
 "The `Mail` instance lets you add recipients (to, cc, or bcc), set the subject, headers, sender (from) address..."
-msgstr "O mailer permite que o senhor envie objetos `io.quarkus.mailer.Mail` . O senhor pode criar novas instâncias de `io.quarkus.mailer.Mail` com o construtor ou com os métodos auxiliares `Mail.withText` e `Mail.withHtml` . A instância `Mail` permite que o senhor adicione destinatários (para, cc ou bcc), defina o assunto, os cabeçalhos, o endereço do remetente (de)..."
+msgstr ""
+"O mailer permite enviar objetos `io.quarkus.mailer.Mail`.\n"
+"Você pode criar novas instâncias de `io.quarkus.mailer.Mail` a partir do construtor ou dos métodos auxiliares `Mail.withText` e\n"
+"`Mail.withHtml`.\n"
+"A instância `Mail` permite adicionar destinatários (to, cc ou bcc), definir o assunto, cabeçalhos, endereço do remetente (from)..."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Most of these properties are optional, but the sender address is required. It can either be set on an individual `Mail` instances using"
-msgstr "A maioria dessas propriedades é opcional, mas o endereço do remetente é obrigatório. Ele pode ser definido em uma instância individual do `Mail` usando o"
+msgstr "A maioria dessas propriedades é opcional, mas o endereço do remetente é obrigatório. Ele pode ser definido em instâncias individuais do `Mail` usando"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "or a global default can be configured, using"
 msgstr "ou um padrão global pode ser configurado, usando"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "You can also send several `Mail` objects in one call:"
-msgstr "O senhor também pode enviar vários objetos `Mail` em uma única chamada:"
+msgstr "Você também pode enviar vários objetos `Mail` em uma única chamada:"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Sending attachments"
-msgstr "Envio de anexos"
+msgstr "Enviando anexos"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "To send attachments, just use the `addAttachment` methods on the `io.quarkus.mailer.Mail` instance:"
-msgstr "Para enviar anexos, basta usar os métodos `addAttachment` na instância `io.quarkus.mailer.Mail` :"
+msgstr "Para enviar anexos, basta usar os métodos `addAttachment` na instância `io.quarkus.mailer.Mail`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "Attachments can be created from raw bytes (as shown in the snippet) or files.\n"
 "Note that files are resolved from the working directory of the application."
-msgstr "Os anexos podem ser criados a partir de bytes brutos (como mostrado no snippet) ou de arquivos. Observe que os arquivos são resolvidos a partir do diretório de trabalho do aplicativo."
+msgstr ""
+"Anexos podem ser criados a partir de bytes puros (como mostrado no trecho de código) ou arquivos.\n"
+"Observe que os arquivos são resolvidos a partir do diretório de trabalho da aplicação."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Sending HTML emails with inlined attachments"
-msgstr "Envio de e-mails em HTML com anexos sublinhados"
+msgstr "Enviando e-mails HTML com anexos embutidos (inline)"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "When sending HTML emails, you can add inlined attachments.\n"
 "For example, you can send an image with your email, and this image will be displayed in the mail content.\n"
 "If you put the image file into the `META-INF/resources` folder, you should specify the full path to the file, _e.g._ `META-INF/resources/quarkus-logo.png` otherwise Quarkus will look for the file in the root directory."
-msgstr "Ao enviar e-mails em HTML, o senhor pode adicionar anexos sublinhados. Por exemplo, o senhor pode enviar uma imagem com o e-mail, e essa imagem será exibida no conteúdo do e-mail. Se o senhor colocar o arquivo de imagem na pasta `META-INF/resources` , deverá especificar o caminho completo para o arquivo, _por exemplo_ , `META-INF/resources/quarkus-logo.png` ; caso contrário, o Quarkus procurará o arquivo no diretório raiz."
+msgstr ""
+"Ao enviar e-mails HTML, você pode adicionar anexos embutidos.\n"
+"Por exemplo, você pode enviar uma imagem com seu e-mail, e esta imagem será exibida no conteúdo do e-mail.\n"
+"Se você colocar o arquivo de imagem na pasta `META-INF/resources`, você deve especificar o caminho completo para o arquivo, _por exemplo_, `META-INF/resources/quarkus-logo.png`, caso contrário, o Quarkus procurará o arquivo no diretório raiz."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
@@ -187,210 +218,256 @@ msgid ""
 "By spec, when you create the inline attachment, the content-id must be structured as follows: `<id@domain>`.\n"
 "If you don't wrap your content-id between `<>`, it is automatically wrapped for you.\n"
 "When you want to reference your attachment, for instance in the `src` attribute, use `cid:id@domain` (without the `<` and `>`)."
-msgstr "Observe o formato e a referência do _content-id_ . Por especificação, quando o senhor cria o anexo inline, o content-id deve ser estruturado da seguinte forma: `<id@domain>` . Se o senhor não envolver o content-id entre `<>` , ele será automaticamente envolvido para o senhor. Quando o senhor quiser fazer referência ao seu anexo, por exemplo, no atributo `src` , use `cid:id@domain` (sem `<` e `>` )."
+msgstr ""
+"Observe o formato e a referência do _content-id_.\n"
+"De acordo com a especificação, ao criar o anexo inline, o content-id deve ser estruturado da seguinte forma: `<id@domain>`.\n"
+"Se você não envolver seu content-id entre `<>`, ele será envolvido automaticamente para você.\n"
+"Quando quiser referenciar seu anexo, por exemplo, no atributo `src`, use `cid:id@domain` (sem o `<` e `>`)."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Message Body Based on Qute Templates"
-msgstr "Corpo da mensagem baseado em modelos Qute"
+msgstr "Corpo da Mensagem Baseado em Templates Qute"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "It's also possible to send an e-mail where the message body is created automatically using xref:qute.adoc[Qute templates]."
-msgstr "Também é possível enviar um e-mail em que o corpo da mensagem é criado automaticamente usando xref:qute.adoc[os modelos do Qute] ."
+msgstr "Também é possível enviar um e-mail onde o corpo da mensagem é criado automaticamente usando xref:qute.adoc[templates Qute]."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "You can define a type-safe mail template in your Java code.\n"
 "Just annotate a class with `@io.quarkus.qute.CheckedTemplate` and all its `static native` methods that return `MailTemplate` will be used to define type-safe mail templates and the list of parameters they require:"
-msgstr "O senhor pode definir um modelo de e-mail seguro para o tipo em seu código Java. Basta anotar uma classe com `@io.quarkus.qute.CheckedTemplate` e todos os seus métodos `static native` que retornam `MailTemplate` serão usados para definir modelos de e-mail seguros para o tipo e a lista de parâmetros que eles exigem:"
+msgstr ""
+"Você pode definir um template de e-mail com segurança de tipos (type-safe) em seu código Java.\n"
+"Basta anotar uma classe com `@io.quarkus.qute.CheckedTemplate` e todos os seus métodos `static native` que retornam `MailTemplate` serão usados para definir templates de e-mail type-safe e a lista de parâmetros que eles exigem:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "By convention, the enclosing class name and method names are used to locate the template. In this particular case,\n"
 "we will use the `src/main/resources/templates/MailingResource/hello.html` and `src/main/resources/templates/MailingResource/hello.txt` templates to create the message body."
-msgstr "Por convenção, o nome da classe e os nomes dos métodos que a compõem são usados para localizar o modelo. Nesse caso específico, usaremos os modelos `src/main/resources/templates/MailingResource/hello.html` e `src/main/resources/templates/MailingResource/hello.txt` para criar o corpo da mensagem."
+msgstr ""
+"Por convenção, o nome da classe envolvente e os nomes dos métodos são usados para localizar o template. Neste caso em particular,\n"
+"usaremos os templates `src/main/resources/templates/MailingResource/hello.html` e `src/main/resources/templates/MailingResource/hello.txt` para criar o corpo da mensagem."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Set the data used in the template."
-msgstr "Definir os dados usados no modelo."
+msgstr "Define os dados usados no template."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Create a mail template instance and set the recipient."
-msgstr "Crie uma instância de modelo de correio eletrônico e defina o destinatário."
+msgstr "Cria uma instância de template de e-mail e define o destinatário."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "`MailTemplate.send()` triggers the rendering and, once finished, sends the e-mail via a `Mailer` instance."
-msgstr "`MailTemplate.send()` aciona a renderização e, uma vez concluída, envia o e-mail por meio de uma instância do `Mailer` ."
+msgstr "`MailTemplate.send()` aciona a renderização e, uma vez finalizada, envia o e-mail através de uma instância do `Mailer`."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "Alternatively, use a Java record that implements `io.quarkus.mailer.MailTemplate`.\n"
 "The record components represent the template parameters."
-msgstr "Como alternativa, use um registro Java que implemente `io.quarkus.mailer.MailTemplate` . Os componentes do registro representam os parâmetros do modelo."
+msgstr ""
+"Alternativamente, use um record Java que implemente `io.quarkus.mailer.MailTemplate`.\n"
+"Os componentes do record representam os parâmetros do template."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "By convention, the enclosing class name and the record name are used to locate the template. In this particular case,\n"
 "we will use the `src/main/resources/templates/MailingResource/hello.html` and `src/main/resources/templates/MailingResource/hello.txt` templates to create the message body."
-msgstr "Por convenção, o nome da classe envolvente e o nome do registro são usados para localizar o modelo. Nesse caso específico, usaremos os modelos `src/main/resources/templates/MailingResource/hello.html` e `src/main/resources/templates/MailingResource/hello.txt` para criar o corpo da mensagem."
+msgstr ""
+"Por convenção, o nome da classe envolvente e o nome do record são usados para localizar o template. Neste caso em particular,\n"
+"usaremos os templates `src/main/resources/templates/MailingResource/hello.html` e `src/main/resources/templates/MailingResource/hello.txt` para criar o corpo da mensagem."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "You can also do this without type-safe templates:"
-msgstr "O senhor também pode fazer isso sem modelos type-safe:"
+msgstr "Você também pode fazer isso sem templates type-safe:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "If there is no `@Location` qualifier provided, the field name is used to locate the template.\n"
 "Otherwise, search for the template as the specified location. In this particular case, we will use the `src/main/resources/templates/hello.html` and `src/main/resources/templates/hello.txt` templates to create the message body."
-msgstr "Se não houver um qualificador `@Location` fornecido, o nome do campo será usado para localizar o modelo. Caso contrário, o senhor procurará o modelo como o local especificado. Nesse caso específico, usaremos os modelos `src/main/resources/templates/hello.html` e `src/main/resources/templates/hello.txt` para criar o corpo da mensagem."
+msgstr ""
+"Se nenhum qualificador `@Location` for fornecido, o nome do campo será usado para localizar o template.\n"
+"Caso contrário, a busca pelo template será feita no local especificado. Neste caso em particular, usaremos os templates `src/main/resources/templates/hello.html` e `src/main/resources/templates/hello.txt` para criar o corpo da mensagem."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "Injected mail templates are validated during build.\n"
 "The build fails if there is no matching template in `src/main/resources/templates`."
-msgstr "Os modelos de e-mail injetados são validados durante a criação. A compilação falhará se não houver um modelo correspondente em `src/main/resources/templates` ."
+msgstr ""
+"Templates de e-mail injetados são validados durante o build.\n"
+"O build falha se não houver um template correspondente em `src/main/resources/templates`."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Execution model"
 msgstr "Modelo de execução"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "The reactive mailer is non-blocking, and the results are provided on an I/O thread.\n"
 "See the xref:quarkus-reactive-architecture.adoc[Quarkus Reactive Architecture documentation] for further details on this topic."
-msgstr "O mailer reativo não tem bloqueio e os resultados são fornecidos em um thread de E/S. Consulte a xref:quarkus-reactive-architecture.adoc[documentação da Arquitetura Reativa do Quarkus] para obter mais detalhes sobre esse tópico."
+msgstr ""
+"O mailer reativo não é bloqueante e os resultados são fornecidos em uma thread de E/S.\n"
+"Consulte a xref:quarkus-reactive-architecture.adoc[documentação da Arquitetura Reativa do Quarkus] para mais detalhes sobre este tópico."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "The non-reactive mailer blocks until the messages are sent to the SMTP server.\n"
 "Note that does not mean that the message is delivered, just that it's been sent successfully to the SMTP server, which will be responsible for the delivery."
-msgstr "O mailer não reativo bloqueia até que as mensagens sejam enviadas para o servidor SMTP. Observe que isso não significa que a mensagem foi entregue, apenas que ela foi enviada com êxito ao servidor SMTP, que será responsável pela entrega."
+msgstr ""
+"O mailer não reativo bloqueia até que as mensagens sejam enviadas ao servidor SMTP.\n"
+"Note que isso não significa que a mensagem foi entregue, apenas que foi enviada com sucesso para o servidor SMTP, que será o responsável pela entrega."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Testing email sending"
-msgstr "Teste de envio de e-mail"
+msgstr "Testando o envio de e-mails"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "Because it is very inconvenient to send emails during development and testing, you can set the `quarkus.mailer.mock` boolean\n"
 "configuration to `true` to prevent the actual sending of emails but instead print them on stdout and collect them in a `MockMailbox` bean instead.\n"
 "This is the default if you are running Quarkus in dev or test mode."
-msgstr "Como é muito inconveniente enviar e-mails durante o desenvolvimento e os testes, o senhor pode definir a configuração booleana `quarkus.mailer.mock` como `true` para impedir o envio real de e-mails, mas, em vez disso, imprimi-los no stdout e coletá-los em um bean `MockMailbox` . Esse é o padrão se o senhor estiver executando o Quarkus no modo de desenvolvimento ou teste."
+msgstr ""
+"Como é muito inconveniente enviar e-mails durante o desenvolvimento e os testes, você pode definir a configuração booleana `quarkus.mailer.mock` como `true` para evitar o envio real de e-mails e, em vez disso, imprimi-los no stdout e coletá-los em um bean `MockMailbox` em seu lugar.\n"
+"Este é o padrão se você estiver executando o Quarkus em modo dev ou test."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "You can then write tests to verify that your emails were sent, for example, by a REST endpoint:"
-msgstr "O senhor pode então escrever testes para verificar se os e-mails foram enviados, por exemplo, por um endpoint REST:"
+msgstr "Você pode então escrever testes para verificar se seus e-mails foram enviados, por exemplo, por um endpoint REST:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "Another option is to use the  https://github.com/quarkiverse/quarkus-mailpit[Quarkus Mailpit] extension\n"
 "which provides Dev Services for https://github.com/axllent/mailpit[Mailpit], a nice UI for testing and debugging email sending."
-msgstr "Outra opção é usar a extensão link:https://github.com/quarkiverse/quarkus-mailpit[Quarkus Mailpit] , que fornece Dev Services for link:https://github.com/axllent/mailpit[Mailpit] , uma boa interface de usuário para testar e depurar o envio de e-mails."
+msgstr ""
+"Outra opção é usar a extensão https://github.com/quarkiverse/quarkus-mailpit[Quarkus Mailpit],\n"
+"que fornece Dev Services para o https://github.com/axllent/mailpit[Mailpit], uma interface amigável para testar e depurar o envio de e-mails."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Using the underlying Vert.x Mail Client"
-msgstr "Usando o cliente de correio Vert.x subjacente"
+msgstr "Usando o Vert.x Mail Client subjacente"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "The Quarkus Mailer is implemented on top of the https://vertx.io/docs/vertx-mail-client/java/[Vert.x Mail Client], providing an asynchronous and non-blocking way to send emails.\n"
 "If you need fine control on how the mail is sent, for instance if you need to retrieve the message ids, you can inject the underlying client, and use it directly:"
-msgstr "O Quarkus Mailer é implementado sobre o link:https://vertx.io/docs/vertx-mail-client/java/[Vert.x Mail Client] , fornecendo uma maneira assíncrona e sem bloqueio de enviar e-mails. Se precisar de um controle preciso sobre como o e-mail é enviado, por exemplo, se precisar recuperar os IDs das mensagens, poderá injetar o cliente subjacente e usá-lo diretamente:"
+msgstr ""
+"O Quarkus Mailer é implementado sobre o https://vertx.io/docs/vertx-mail-client/java/[Vert.x Mail Client], fornecendo uma maneira assíncrona e não bloqueante de enviar e-mails.\n"
+"Se você precisar de um controle refinado sobre como o e-mail é enviado, por exemplo, se precisar recuperar os IDs das mensagens, você pode injetar o cliente subjacente e usá-lo diretamente:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Three API flavors are exposed:"
-msgstr "Três tipos de API são expostos:"
+msgstr "Três variações de API são expostas:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "the Mutiny client (`io.vertx.mutiny.ext.mail.MailClient`)"
-msgstr "O cliente da Mutiny ( `io.vertx.mutiny.ext.mail.MailClient` )"
+msgstr "o cliente Mutiny (`io.vertx.mutiny.ext.mail.MailClient`)"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "the bare client (`io.vertx.ext.mail.MailClient`)"
-msgstr "O cliente simples ( `io.vertx.ext.mail.MailClient` )"
+msgstr "o cliente puro (`io.vertx.ext.mail.MailClient`)"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Check the xref:vertx.adoc[Using Vert.x guide] for further details about these different APIs and how to select the most suitable for you."
-msgstr "Consulte o xref:vertx.adoc[guia Using Vert.x] para obter mais detalhes sobre essas diferentes APIs e como selecionar a mais adequada para o senhor."
+msgstr "Consulte o guia xref:vertx.adoc[Usando Vert.x] para mais detalhes sobre essas diferentes APIs e como selecionar a mais adequada para você."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "The retrieved `MailClient` is configured using the configuration property presented above.\n"
 "You can also create your own instance, and pass your own configuration."
-msgstr "O site `MailClient` recuperado é configurado usando a propriedade de configuração apresentada acima. O senhor também pode criar sua própria instância e passar sua própria configuração."
+msgstr ""
+"O `MailClient` recuperado é configurado usando a propriedade de configuração apresentada acima.\n"
+"Você também pode criar sua própria instância e passar sua própria configuração."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Using SSL with native executables"
-msgstr "Uso de SSL com executáveis nativos"
+msgstr "Usando SSL com executáveis nativos"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "Note that if you enable SSL for the mailer and you want to build a native executable, you will need to enable the SSL support.\n"
 "Please refer to the xref:native-and-ssl.adoc[Using SSL With Native Executables] guide for more information."
-msgstr "Observe que, se o senhor ativar o SSL para o mailer e quiser criar um executável nativo, precisará ativar o suporte a SSL. Consulte o guia xref:native-and-ssl.adoc[Using SSL With Native Executables (Usando SSL com executáveis nativos] ) para obter mais informações."
+msgstr ""
+"Observe que, se você habilitar o SSL para o mailer e quiser construir um executável nativo, será necessário habilitar o suporte a SSL.\n"
+"Consulte o guia xref:native-and-ssl.adoc[Usando SSL com Executáveis Nativos] para mais informações."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Configuring the SMTP credentials"
-msgstr "Configuração das credenciais de SMTP"
+msgstr "Configurando as credenciais SMTP"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
@@ -398,365 +475,412 @@ msgid ""
 "One approach is to save the value into a secure store like HashiCorp Vault, and refer to it from the configuration.\n"
 "Assuming for instance that Vault contains key `mail-password` at path `myapps/myapp/myconfig`, then the mailer\n"
 "extension can be simply configured as:"
-msgstr "Recomenda-se criptografar todos os dados confidenciais, como `quarkus.mailer.password` . Uma abordagem é salvar o valor em um armazenamento seguro, como o HashiCorp Vault, e fazer referência a ele na configuração. Supondo, por exemplo, que o Vault contenha a chave `mail-password` no caminho `myapps/myapp/myconfig` , a extensão do mailer pode ser simplesmente configurada como:"
+msgstr ""
+"Recomenda-se criptografar quaisquer dados sensíveis, como o `quarkus.mailer.password`.\n"
+"Uma abordagem é salvar o valor em um armazenamento seguro como o HashiCorp Vault e referenciá-lo a partir da configuração.\n"
+"Supondo, por exemplo, que o Vault contenha a chave `mail-password` no caminho `myapps/myapp/myconfig`, então a extensão do mailer pode ser configurada simplesmente como:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "Please note that the password value is evaluated only once, at startup time. If `mail-password` was changed in Vault,\n"
 "the only way to get the new value would be to restart the application."
-msgstr "Observe que o valor da senha é avaliado apenas uma vez, no momento da inicialização. Se o site `mail-password` tiver sido alterado no Vault, a única maneira de obter o novo valor seria reiniciar o aplicativo."
+msgstr "Observe que o valor da senha é avaliado apenas uma vez, no momento da inicialização. Se `mail-password` for alterado no Vault, a única maneira de obter o novo valor seria reiniciar a aplicação."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "Do use Vault, you need the https://github.com/quarkiverse/quarkus-vault[Quarkus Vault] extension.\n"
 "More details about this extension and its configuration can be found in the https://docs.quarkiverse.io/quarkus-vault/dev/index.html[extension documentation]."
-msgstr "Para usar o Vault, o senhor precisa da extensão link:https://github.com/quarkiverse/quarkus-vault[Quarkus Vault] . Mais detalhes sobre essa extensão e sua configuração podem ser encontrados na link:https://docs.quarkiverse.io/quarkus-vault/dev/index.html[documentação da extensão] ."
+msgstr ""
+"Para usar o Vault, você precisa da extensão https://github.com/quarkiverse/quarkus-vault[Quarkus Vault].\n"
+"Mais detalhes sobre esta extensão e sua configuração podem ser encontrados na https://docs.quarkiverse.io/quarkus-vault/dev/index.html[documentação da extensão]."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "For more information about the Mailer configuration please refer to the <<configuration-reference,Configuration Reference>>."
-msgstr "Para obter mais informações sobre a configuração do Mailer, consulte a xref:configuration-reference[Referência de configuração] ."
+msgstr "Para obter mais informações sobre a configuração do Mailer, consulte a <<configuration-reference,Referência de Configuração>>."
 
-#. type: Title =
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Configuring TLS"
-msgstr "Configuração do TLS"
+msgstr "Configurando TLS"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "SMTP provides various way to use TLS:"
-msgstr "O SMTP oferece várias maneiras de usar o TLS:"
+msgstr "O SMTP fornece várias maneiras de usar TLS:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "StartTLS: The client connects to the server using a plain connection and then upgrades to a secure connection."
-msgstr "StartTLS: O cliente se conecta ao servidor usando uma conexão simples e, em seguida, faz o upgrade para uma conexão segura."
+msgstr "StartTLS: O cliente se conecta ao servidor usando uma conexão simples e então faz o upgrade para uma conexão segura."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "SSL/TLS: The client connects to the server using a secure connection from the start."
 msgstr "SSL/TLS: O cliente se conecta ao servidor usando uma conexão segura desde o início."
 
-#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Configuring STARTTLS"
-msgstr "Configuração do STARTTLS"
+msgstr "Configurando STARTTLS"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "To use `STARTTLS`, you need to configure the `start-tls` property to `REQUIRED` or `OPTIONAL` and set `tls` to `false`:"
-msgstr "Para usar `STARTTLS` , o senhor precisa configurar a propriedade `start-tls` para `REQUIRED` ou `OPTIONAL` e definir `tls` para `false` :"
+msgstr "Para usar `STARTTLS`, você precisa configurar a propriedade `start-tls` como `REQUIRED` ou `OPTIONAL` e definir `tls` como `false`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Setting `tls` to `false` ensure we connect using a plain connection and then upgrade to a secure connection using `STARTTLS`."
-msgstr "A configuração de `tls` para `false` garante que nos conectemos usando uma conexão simples e, em seguida, atualizemos para uma conexão segura usando `STARTTLS` ."
+msgstr "Definir `tls` como `false` garante que nos conectaremos usando uma conexão simples e então faremos o upgrade para uma conexão segura usando `STARTTLS`."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "To configure the trust store, you can use a _named_ TLS configuration stored in the xref:./tls-registry-reference.adoc[TLS registry]:"
-msgstr "Para configurar o trust store, é possível usar uma configuração TLS _nomeada_ armazenada no xref:./tls-registry-reference.adoc[registro TLS] :"
+msgstr "Para configurar o trust store, você pode usar uma configuração TLS _nomeada_ armazenada no xref:./tls-registry-reference.adoc[registro TLS]:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "While not recommended, you can trust all certificates by setting `quarkus.tls.trust-all` to `true`:"
-msgstr "Embora não seja recomendado, o senhor pode confiar em todos os certificados definindo `quarkus.tls.trust-all` como `true` :"
+msgstr "Embora não seja recomendado, você pode confiar em todos os certificados definindo `quarkus.tls.trust-all` como `true`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Alternatively, you can use the _deprecated_ `quarkus.mailer.trust-store.paths`  and `quarkus.mailer.trust-all` properties:"
-msgstr "Como alternativa, o senhor pode usar as propriedades _obsoletas_ `quarkus.mailer.trust-store.paths` e `quarkus.mailer.trust-all` :"
+msgstr "Alternativamente, você pode usar as propriedades _descontinuadas_ `quarkus.mailer.trust-store.paths` e `quarkus.mailer.trust-all`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "To use `START_TLS`, make sure you set `tls` to `false` and `start-tls` to `REQUIRED` or `OPTIONAL`."
-msgstr "Para usar `START_TLS` , certifique-se de definir `tls` como `false` e `start-tls` como `REQUIRED` ou `OPTIONAL` ."
+msgstr "Para usar `START_TLS`, certifique-se de definir `tls` como `false` e `start-tls` como `REQUIRED` ou `OPTIONAL`."
 
-#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Configuring SSL/TLS"
-msgstr "Configuração de SSL/TLS"
+msgstr "Configurando SSL/TLS"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "To establish a TLS connection, you need to configure a _named_ configuration using the xref:./tls-registry-reference.adoc[TLS registry]:"
-msgstr "Para estabelecer uma conexão TLS, é necessário definir uma configuração _nomeada_ usando o xref:./tls-registry-reference.adoc[registro TLS] :"
+msgstr "Para estabelecer uma conexão TLS, você precisa configurar uma configuração _nomeada_ usando o xref:./tls-registry-reference.adoc[registro TLS]:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "When using the mailer, using a _named_ configuration is required to avoid conflicts with other TLS configurations.\n"
 "The mailer will not use the default TLS configuration."
-msgstr "Ao usar o mailer, é necessário usar uma configuração _nomeada_ para evitar conflitos com outras configurações de TLS. O mailer não usará a configuração padrão de TLS."
+msgstr ""
+"Ao usar o mailer, o uso de uma configuração _nomeada_ é obrigatório para evitar conflitos com outras configurações TLS.\n"
+"O mailer não usará a configuração TLS padrão."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "When you configure a _named_ TLS configuration, TLS is enabled by default.\n"
 "If your SMTP server uses a valid (trusted) certificate, and thus do not require a specific TLS configuration, you need to enable TLS explicitly (as you do not have to configure a trust store):"
-msgstr "Quando o senhor define uma configuração de TLS _nomeada_ , o TLS é ativado por padrão. Se o seu servidor SMTP usar um certificado válido (confiável) e, portanto, não exigir uma configuração específica de TLS, o senhor precisará ativar o TLS explicitamente (já que não precisa configurar um armazenamento confiável):"
+msgstr ""
+"Ao configurar uma configuração TLS _nomeada_, o TLS é habilitado por padrão.\n"
+"Se o seu servidor SMTP usar um certificado válido (confiável) e, portanto, não exigir uma configuração TLS específica, você precisará habilitar o TLS explicitamente (já que não precisa configurar um trust store):"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "When `quarkus.tls.trust-all` is set to `true`, the trust store configuration is ignored. This is not recommended for production.\n"
 "Also, we recommend avoiding using `quarkus.tls.trust-all`, and use a named configuration instead if `trust-all` is required:"
-msgstr "Quando `quarkus.tls.trust-all` é definido como `true` , a configuração do trust store é ignorada. Isso não é recomendado para produção. Além disso, recomendamos que o senhor evite usar `quarkus.tls.trust-all` e, em vez disso, use uma configuração nomeada se `trust-all` for necessário:"
+msgstr ""
+"Quando `quarkus.tls.trust-all` é definido como `true`, a configuração do trust store é ignorada. Isso não é recomendado para produção.\n"
+"Além disso, recomendamos evitar o uso de `quarkus.tls.trust-all` e usar uma configuração nomeada em vez disso, caso `trust-all` seja necessário:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "You can also use the deprecated `quarkus.mailer.trust-all=true` property."
-msgstr "O senhor também pode usar a propriedade `quarkus.mailer.trust-all=true` , que está obsoleta."
+msgstr "Você também pode usar a propriedade descontinuada `quarkus.mailer.trust-all=true`."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Multiple mailer configurations"
-msgstr "Múltiplas configurações de mala direta"
+msgstr "Múltiplas configurações de mailer"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Some applications require to send mails through different SMTP servers."
-msgstr "Alguns aplicativos exigem o envio de e-mails por meio de diferentes servidores SMTP."
+msgstr "Algumas aplicações exigem o envio de e-mails através de diferentes servidores SMTP."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "This use case is perfectly supported in Quarkus and you can configure several mailers:"
-msgstr "Esse caso de uso é perfeitamente compatível com o Quarkus e o senhor pode configurar vários remetentes:"
+msgstr "Este caso de uso é perfeitamente suportado no Quarkus e você pode configurar vários mailers:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Configuration for the default mailer."
 msgstr "Configuração para o mailer padrão."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Configuration for a mailer named `aws`."
-msgstr "Configuração de um mailer chamado `aws` ."
+msgstr "Configuração para um mailer chamado `aws`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Configuration for a mailer named `sendgrid`."
-msgstr "Configuração de um mailer chamado `sendgrid` ."
+msgstr "Configuração para um mailer chamado `sendgrid`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Then, access your named mailers by using the `@MailerName` CDI qualifier:"
-msgstr "Em seguida, acesse seus mailers nomeados usando o qualificador `@MailerName` CDI:"
+msgstr "Em seguida, acesse seus mailers nomeados usando o qualificador CDI `@MailerName`:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Inject instances without qualifier for the default configuration."
-msgstr "Injetar instâncias sem qualificador para a configuração padrão."
+msgstr "Injete instâncias sem qualificador para a configuração padrão."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Inject instances with the `@MailerName(\"aws\")` qualifier for the `aws` configuration."
-msgstr "Injetar instâncias com o qualificador `@MailerName(\"aws\")` para a configuração `aws` ."
+msgstr "Injete instâncias com o qualificador `@MailerName(\"aws\")` para a configuração `aws`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Inject instances with the `@MailerName(\"sendgrid\")` qualifier for the `sendgrid` configuration."
-msgstr "Injetar instâncias com o qualificador `@MailerName(\"sendgrid\")` para a configuração `sendgrid` ."
+msgstr "Injete instâncias com o qualificador `@MailerName(\"sendgrid\")` para a configuração `sendgrid`."
 
-#. type: Plain text
+#. type: delimited block =
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Type-safe template using `@CheckedTemplate` are currently only supported for the default mailer configuration."
-msgstr "O modelo seguro de tipo usando `@CheckedTemplate` é atualmente compatível apenas com a configuração padrão do mailer."
+msgstr "Templates type-safe usando `@CheckedTemplate` são atualmente suportados apenas para a configuração do mailer padrão."
 
-#. type: Plain text
+#. type: delimited block =
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Use `MailTemplate` injection for the named mailer configurations."
-msgstr "Use a injeção `MailTemplate` para as configurações de mailer nomeadas."
+msgstr "Use a injeção de `MailTemplate` para as configurações de mailer nomeadas."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Mailer configuration for popular email services"
-msgstr "Configuração do mailer para serviços de e-mail populares"
+msgstr "Configuração do Mailer para serviços de e-mail populares"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "This section provides the configurations to use with popular mail services."
-msgstr "Esta seção fornece as configurações a serem usadas com serviços de correio populares."
+msgstr "Esta seção fornece as configurações para usar com serviços de e-mail populares."
 
-#. type: Title ==
+#. type: Title ===
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Gmail specific configuration"
 msgstr "Configuração específica do Gmail"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "If you want to use the Gmail SMTP server, first create a dedicated password in `Google Account > Security > App passwords` or go to https://myaccount.google.com/apppasswords."
-msgstr "Se o senhor quiser usar o servidor SMTP do Gmail, primeiro crie uma senha dedicada em `Google Account > Security > App passwords` ou acesse link:https://myaccount.google.com/apppasswords[https://myaccount.google.com/apppasswords.]"
+msgstr "Se você quiser usar o servidor SMTP do Gmail, primeiro crie uma senha dedicada em `Conta do Google > Segurança > Senhas de app` ou acesse https://myaccount.google.com/apppasswords."
 
-#. type: Plain text
+#. type: delimited block =
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "You need to switch on 2-Step Verification at https://myaccount.google.com/security in order to access the App passwords page."
-msgstr "O senhor precisa ativar a verificação em duas etapas em https://myaccount.google.com/security para acessar a página de senhas do aplicativo."
+msgstr "Você precisa ativar a Verificação em duas etapas em https://myaccount.google.com/security para acessar a página Senhas de app."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "When done, you can configure your Quarkus application by adding the following properties to your `application.properties`:"
-msgstr "Quando terminar, o senhor pode configurar o aplicativo Quarkus adicionando as seguintes propriedades ao site `application.properties` :"
+msgstr "Quando terminar, você poderá configurar sua aplicação Quarkus adicionando as seguintes propriedades ao seu `application.properties`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "With `STARTTLS`:"
-msgstr "Com `STARTTLS` :"
+msgstr "Com `STARTTLS`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Or with TLS/SSL:"
 msgstr "Ou com TLS/SSL:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "The `quarkus.mailer.auth-methods` configuration option is needed for the Quarkus mailer to support password authentication with Gmail.\n"
 "By default, both the mailer and Gmail default to `XOAUTH2` which requires registering an application, getting tokens, etc."
-msgstr "A opção de configuração `quarkus.mailer.auth-methods` é necessária para que o Quarkus mailer ofereça suporte à autenticação de senha com o Gmail. Por padrão, o mailer e o Gmail usam `XOAUTH2` , o que exige o registro de um aplicativo, a obtenção de tokens, etc."
+msgstr ""
+"A opção de configuração `quarkus.mailer.auth-methods` é necessária para que o mailer do Quarkus suporte a autenticação por senha com o Gmail.\n"
+"Por padrão, tanto o mailer quanto o Gmail usam `XOAUTH2`, o que exige o registro de uma aplicação, obtenção de tokens, etc."
 
-#. type: Title ==
+#. type: Title ===
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "AWS SES - Simple Email Service"
-msgstr "AWS SES - Serviço de e-mail simples"
+msgstr "AWS SES - Simple Email Service"
 
-#. type: Title ===
+#. type: Title ====
+#. mt: gemini
 #: _guides/mailer-reference.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Prerequisites"
 msgstr "Pré-requisitos"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "SES Identity Check, follow the process to setup the DKIM verification"
-msgstr "SES Identity Check, siga o processo para configurar a verificação DKIM"
+msgstr "Verificação de Identidade do SES, siga o processo para configurar a verificação DKIM"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Retrieve SMTP endpoint from https://us-east-1.console.aws.amazon.com/ses/home, example: `email-smtp.us-east-1.amazonaws.com`"
-msgstr "Recupere o endpoint SMTP de link:https://us-east-1.console.aws.amazon.com/ses/home[https://us-east-1.console.aws.amazon.com/ses/home,] por exemplo: `email-smtp.us-east-1.amazonaws.com`"
+msgstr "Obtenha o endpoint SMTP em https://us-east-1.console.aws.amazon.com/ses/home, exemplo: `email-smtp.us-east-1.amazonaws.com`"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Create SMTP credentials if needed"
-msgstr "Criar credenciais SMTP, se necessário"
+msgstr "Crie as credenciais SMTP, se necessário"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "If you are in a sandbox, also verify the recipients (using email verification)"
-msgstr "Se o senhor estiver em uma área restrita, verifique também os destinatários (usando a verificação de e-mail)"
+msgstr "Se você estiver em um sandbox, verifique também os destinatários (usando a verificação de e-mail)"
 
-#. type: Title ===
+#. type: Title ====
+#. mt: gemini
 #: _guides/mailer-reference.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Configuration"
 msgstr "Configuração"
 
-#. type: Title ==
+#. type: Title ===
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "MailJet"
 msgstr "MailJet"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid ""
 "The mailjet integration is used on an SMTP relay.\n"
 "You are going to send the email using this SMTP server."
-msgstr "A integração do mailjet é usada em um relé SMTP. O senhor enviará o e-mail usando esse servidor SMTP."
+msgstr ""
+"A integração com o mailjet é usada em um relay SMTP.\n"
+"Você enviará o e-mail usando este servidor SMTP."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Create a mailJet account and the API key / Secret Key"
-msgstr "Criar uma conta mailJet e a chave de API / chave secreta"
+msgstr "Crie uma conta no mailJet e a API key / Secret Key"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "The sender address must be verified (SPF + DKIM) and the email explicitly added to the verified list"
-msgstr "O endereço do remetente deve ser verificado (SPF + DKIM) e o e-mail deve ser adicionado explicitamente à lista de verificação"
+msgstr "O endereço do remetente deve ser verificado (SPF + DKIM) e o e-mail explicitamente adicionado à lista de verificados"
 
-#. type: Title ==
+#. type: Title ===
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Sendgrid"
 msgstr "Sendgrid"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Follow the instruction to verify the sender domain using DKIM"
-msgstr "Siga as instruções para verificar o domínio do remetente usando o DKIM"
+msgstr "Siga as instruções para verificar o domínio do remetente usando DKIM"
 
-#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Office 365"
 msgstr "Office 365"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy
 msgid "Enable SMTP Access to your Office 365 mailbox, you can do it from the administration console (see link:https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/authenticated-client-smtp-submission[this guide] for more information)"
-msgstr "Habilite o acesso SMTP à sua caixa de correio do Office 365, o que pode ser feito no console de administração (consulte link:https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/authenticated-client-smtp-submission[este guia] para obter mais informações)"
+msgstr "Habilite o acesso SMTP à sua caixa de correio do Office 365, você pode fazer isso no console de administração (veja link:https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/authenticated-client-smtp-submission[este guia] para mais informações)"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/mailer-reference.adoc
 #, fuzzy, no-wrap
 msgid "Mailer Configuration Reference"
-msgstr "Referência de configuração do Mailer"
+msgstr "Referência de Configuração do Mailer"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/mailer-reference.adoc
+#, fuzzy
 msgid "<span class=\"icon\"><i class=\"fa fa-lock\" title=\"Fixed at build time\"></i></span> Configuration property fixed at build time - All other configuration properties are overridable at runtime <input type=\"search\" id=\"config-search-0\" placeholder=\"FILTER CONFIGURATION\" disabled>"
-msgstr "<span class=\"icon\"><i class=\"fa fa-lock\" title=\"Fixed at build time\"></i></span> Propriedade de Configuração Fixa no Momento da Compilação - Todas as outras propriedades de configuração podem ser sobrepostas em tempo de execução. <input type=\"search\" id=\"config-search-0\" placeholder=\"FILTER CONFIGURATION\" disabled>"
+msgstr "<span class=\"icon\"><i class=\"fa fa-lock\" title=\"Fixado em tempo de compilação\"></i></span> Propriedade de configuração fixada em tempo de compilação - Todas as outras propriedades de configuração podem ser sobrescritas em tempo de execução <input type=\"search\" id=\"config-search-0\" placeholder=\"FILTRAR CONFIGURAÇÃO\" disabled>"

--- a/l10n/po/pt_BR/_guides/native-and-ssl.adoc.po
+++ b/l10n/po/pt_BR/_guides/native-and-ssl.adoc.po
@@ -9,601 +9,708 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: YAML Front Matter: title
 #. This guide is maintained in the main Quarkus repository
 #. and pull requests should be submitted there:
 #. https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+#. type: Title =
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Using SSL With Native Executables"
-msgstr "Usando SSL com executáveis nativos"
+msgstr "Usando SSL com Executáveis Nativos"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "We are quickly moving to an SSL-everywhere world so being able to use SSL is crucial."
-msgstr "Estamos mudando rapidamente para um mundo com SSL em todos os lugares, portanto, poder usar SSL é crucial."
+msgstr "Estamos nos movendo rapidamente para um mundo com SSL em todos os lugares, então ser capaz de usar SSL é crucial."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
+#, fuzzy
 msgid ""
 "In this guide, we will discuss how you can get your native executables to support SSL,\n"
 "as native executables don't support it out of the box."
-msgstr "Neste guia, discutiremos como você pode obter seus executáveis nativos para oferecer suporte a SSL, já que os executáveis nativos não oferecem suporte imediato a ele."
+msgstr "Neste guia, discutiremos como você pode fazer seus executáveis nativos suportarem SSL, pois os executáveis nativos não o suportam nativamente."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "If you don't plan on using native executables, you can pass your way as in JDK mode, SSL is supported without further manipulations."
-msgstr "Se o senhor não planeja usar executáveis nativos, pode passar do seu jeito, pois no modo JDK, o SSL é suportado sem outras manipulações."
+msgstr "Se você não planeja usar executáveis nativos, você pode seguir seu caminho, pois no modo JDK, o SSL é suportado sem manipulações adicionais."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Prerequisites"
 msgstr "Pré-requisitos"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
+#, fuzzy
 msgid "To complete this guide, you need:"
-msgstr "Para concluir este guia, você precisa:"
+msgstr "Para completar este guia, você precisa de:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "less than 20 minutes"
 msgstr "menos de 20 minutos"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
+#, fuzzy
 msgid "an IDE"
 msgstr "uma IDE"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "GraalVM installed with `JAVA_HOME` and `GRAALVM_HOME` configured appropriately"
-msgstr "GraalVM instalado com `JAVA_HOME` e `GRAALVM_HOME` configurados adequadamente"
+msgstr "GraalVM instalado com `JAVA_HOME` e `GRAALVM_HOME` configurados apropriadamente"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
+#, fuzzy
 msgid "Apache Maven {maven-version}"
 msgstr "Apache Maven {maven-version}"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "This guide is based on the REST client guide, so you should get this Maven project first."
-msgstr "Este guia é baseado no guia do cliente REST, portanto, o senhor deve obter esse projeto Maven primeiro."
+msgstr "Este guia é baseado no guia do cliente REST, então você deve obter este projeto Maven primeiro."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
+#, fuzzy
 msgid "Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive]."
-msgstr "Clone o repositório Git: `git clone {quickstarts-clone-url}`, ou baixe um {quickstarts-archive-url}[arquivo]."
+msgstr "Clone o repositório Git: `git clone {quickstarts-clone-url}` ou baixe um {quickstarts-archive-url}[arquivo]."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "The project is located in the `resteasy-client-quickstart` link:{quickstarts-tree-url}/resteasy-client-quickstart[directory]."
-msgstr "O projeto está localizado no link:{quickstarts-tree-url}/resteasy-client-quickstart[diretório] `resteasy-client-quickstart` ."
+msgstr "O projeto está localizado no link:{quickstarts-tree-url}/resteasy-client-quickstart[diretório] `resteasy-client-quickstart`."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy, no-wrap
 msgid "Looks like it works out of the box?!?"
-msgstr "O senhor acha que ele funciona sem problemas?"
+msgstr "Parece que funciona nativamente?!?"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "If you open the application's configuration file (`src/main/resources/application.properties`), you can see the following line:"
-msgstr "Se o senhor abrir o arquivo de configuração do aplicativo ( `src/main/resources/application.properties` ), verá a seguinte linha:"
+msgstr "Se você abrir o arquivo de configuração da aplicação (`src/main/resources/application.properties`), você poderá ver a seguinte linha:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "which configures our REST client to connect to an SSL REST service."
-msgstr "que configura nosso cliente REST para se conectar a um serviço REST SSL."
+msgstr "que configura nosso cliente REST para conectar a um serviço REST com SSL."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "For the purposes of this guide, we also need to remove the configuration that starts the embedded WireMock server that stubs REST client responses so the tests actually propagate calls to the https://stage.code.quarkus.io/api. Update the test file `src/test/java/org/acme/rest/client/ExtensionsResourceTest.java` and remove the line:"
-msgstr "Para os fins deste guia, também precisamos remover a configuração que inicia o servidor WireMock incorporado que faz stubs das respostas do cliente REST para que os testes realmente propaguem as chamadas para o site link:https://stage.code.quarkus.io/api[https://stage.code.quarkus.io/api.] Atualize o arquivo de teste `src/test/java/org/acme/rest/client/ExtensionsResourceTest.java` e remova a linha:"
+msgstr "Para os fins deste guia, também precisamos remover a configuração que inicia o servidor WireMock embutido que simula as respostas do cliente REST, para que os testes realmente propaguem as chamadas para https://stage.code.quarkus.io/api. Atualize o arquivo de teste `src/test/java/org/acme/rest/client/ExtensionsResourceTest.java` e remova a linha:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "from the `ExtensionsResourceTest` class."
-msgstr "da classe `ExtensionsResourceTest` ."
+msgstr "da classe `ExtensionsResourceTest`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Now let's build the application as a native executable and run the tests:"
-msgstr "Agora, vamos criar o aplicativo como um executável nativo e executar os testes:"
+msgstr "Agora vamos compilar a aplicação como um executável nativo e executar os testes:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "And we obtain the following result:"
 msgstr "E obtemos o seguinte resultado:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "So, yes, it appears it works out of the box and this guide is pretty useless."
-msgstr "Portanto, sim, parece que ele funciona imediatamente e este guia é bastante inútil."
+msgstr "Então, sim, parece que funciona nativamente e este guia é bem inútil."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "It's not. The magic happens when building the native executable:"
-msgstr "Mas não é. A mágica acontece durante a criação do executável nativo:"
+msgstr "Não é. A mágica acontece ao compilar o executável nativo:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "The important part is the following option that was automatically added by Quarkus:"
 msgstr "A parte importante é a seguinte opção que foi adicionada automaticamente pelo Quarkus:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "It enables the native SSL support for your native executable.\n"
 "But you should not set it manually, we have a nice configuration property for this purpose as described below."
-msgstr "Ele ativa o suporte nativo a SSL para seu executável nativo. Mas o senhor não deve defini-la manualmente, pois temos uma propriedade de configuração interessante para essa finalidade, conforme descrito abaixo."
+msgstr "Ela habilita o suporte nativo a SSL para o seu executável nativo. Mas você não deve configurá-la manualmente, temos uma ótima propriedade de configuração para este propósito, conforme descrito abaixo."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "As SSL is de facto the standard nowadays, we decided to enable its support automatically for some of our extensions:"
-msgstr "Como o SSL é, de fato, o padrão atualmente, decidimos ativar seu suporte automaticamente para algumas de nossas extensões:"
+msgstr "Como o SSL é de fato o padrão hoje em dia, decidimos habilitar seu suporte automaticamente para algumas de nossas extensões:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Agroal connection pooling extension (`quarkus-agroal`),"
-msgstr "a extensão de pooling de conexão do Agroal ( `quarkus-agroal` ),"
+msgstr "a extensão de pool de conexões Agroal (`quarkus-agroal`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Amazon Services extension (`quarkus-amazon-*`),"
-msgstr "a extensão do Amazon Services ( `quarkus-amazon-*` ),"
+msgstr "a extensão Amazon Services (`quarkus-amazon-*`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Consul Config extension (`quarkus-config-consul`),"
-msgstr "a extensão Consul Config ( `quarkus-config-consul` ),"
+msgstr "a extensão Consul Config (`quarkus-config-consul`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Elasticsearch client extensions (`quarkus-elasticsearch-rest-client` and `quarkus-elasticsearch-java-client`) and thus the Hibernate Search Elasticsearch extension (`quarkus-hibernate-search-orm-elasticsearch`),"
-msgstr "as extensões de cliente do Elasticsearch ( `quarkus-elasticsearch-rest-client` e `quarkus-elasticsearch-java-client` ) e, portanto, a extensão do Hibernate Search Elasticsearch ( `quarkus-hibernate-search-orm-elasticsearch` ),"
+msgstr "as extensões de cliente Elasticsearch (`quarkus-elasticsearch-rest-client` e `quarkus-elasticsearch-java-client`) e, portanto, a extensão Hibernate Search Elasticsearch (`quarkus-hibernate-search-orm-elasticsearch`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Elytron Security OAuth2 extension (`quarkus-elytron-security-oauth2`),"
-msgstr "a extensão Elytron Security OAuth2 ( `quarkus-elytron-security-oauth2` ),"
+msgstr "a extensão Elytron Security OAuth2 (`quarkus-elytron-security-oauth2`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the gRPC extension (`quarkus-grpc`),"
-msgstr "a extensão gRPC ( `quarkus-grpc` ),"
+msgstr "a extensão gRPC (`quarkus-grpc`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Infinispan Client extension (`quarkus-infinispan-client`)."
-msgstr "a extensão Infinispan Client ( `quarkus-infinispan-client` )."
+msgstr "a extensão Infinispan Client (`quarkus-infinispan-client`)."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Jaeger extension (`quarkus-jaeger`),"
-msgstr "a extensão Jaeger ( `quarkus-jaeger` ),"
+msgstr "a extensão Jaeger (`quarkus-jaeger`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the JGit extension (`quarkus-jgit`),"
-msgstr "a extensão JGit ( `quarkus-jgit` ),"
+msgstr "a extensão JGit (`quarkus-jgit`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the JSch extension (`quarkus-jsch`),"
-msgstr "a extensão JSch ( `quarkus-jsch` ),"
+msgstr "a extensão JSch (`quarkus-jsch`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Kafka Client extension (`quarkus-kafka-client`), if Apicurio Registry 2.x Avro library is used"
-msgstr "a extensão Kafka Client ( `quarkus-kafka-client` ), se a biblioteca Avro do Apicurio Registry 2.x for usada"
+msgstr "a extensão Kafka Client (`quarkus-kafka-client`), se a biblioteca Avro do Apicurio Registry 2.x for usada"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Keycloak Authorization extension (`quarkus-keycloak-authorization`),"
-msgstr "a extensão Keycloak Authorization ( `quarkus-keycloak-authorization` ),"
+msgstr "a extensão Keycloak Authorization (`quarkus-keycloak-authorization`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Kubernetes client extension (`quarkus-kubernetes-client`),"
-msgstr "a extensão do cliente Kubernetes ( `quarkus-kubernetes-client` ),"
+msgstr "a extensão de cliente Kubernetes (`quarkus-kubernetes-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Logging Sentry extension (`quarkus-logging-sentry`),"
-msgstr "a extensão Logging Sentry ( `quarkus-logging-sentry` ),"
+msgstr "a extensão Logging Sentry (`quarkus-logging-sentry`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Mailer extension (`quarkus-mailer`),"
-msgstr "a extensão Mailer ( `quarkus-mailer` ),"
+msgstr "a extensão Mailer (`quarkus-mailer`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the MongoDB client extension (`quarkus-mongodb-client`),"
-msgstr "a extensão do cliente MongoDB ( `quarkus-mongodb-client` ),"
+msgstr "a extensão de cliente MongoDB (`quarkus-mongodb-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Neo4j extension (`quarkus-neo4j`),"
-msgstr "a extensão Neo4j ( `quarkus-neo4j` ),"
+msgstr "a extensão Neo4j (`quarkus-neo4j`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the OIDC and OIDC client extensions (`quarkus-oidc` and `quarkus-oidc-client`),"
-msgstr "as extensões de cliente OIDC e OIDC ( `quarkus-oidc` e `quarkus-oidc-client` ),"
+msgstr "as extensões OIDC e cliente OIDC (`quarkus-oidc` e `quarkus-oidc-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Reactive client for IBM DB2 extension (`quarkus-reactive-db2-client`),"
-msgstr "o cliente reativo para a extensão do IBM DB2 ( `quarkus-reactive-db2-client` ),"
+msgstr "a extensão de cliente Reativo para IBM DB2 (`quarkus-reactive-db2-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Reactive client for PostgreSQL extension (`quarkus-reactive-pg-client`),"
-msgstr "o cliente reativo para a extensão PostgreSQL ( `quarkus-reactive-pg-client` ),"
+msgstr "a extensão de cliente Reativo para PostgreSQL (`quarkus-reactive-pg-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Reactive client for MySQL extension (`quarkus-reactive-mysql-client`),"
-msgstr "o cliente reativo para a extensão MySQL ( `quarkus-reactive-mysql-client` ),"
+msgstr "a extensão de cliente Reativo para MySQL (`quarkus-reactive-mysql-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Reactive client for Microsoft SQL Server extension (`quarkus-reactive-mssql-client`),"
-msgstr "o cliente reativo para a extensão do Microsoft SQL Server ( `quarkus-reactive-mssql-client` ),"
+msgstr "a extensão de cliente Reativo para Microsoft SQL Server (`quarkus-reactive-mssql-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Redis client extension (`quarkus-redis-client`),"
-msgstr "a extensão do cliente Redis ( `quarkus-redis-client` ),"
+msgstr "a extensão de cliente Redis (`quarkus-redis-client`),"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the RESTEasy Classic REST Client extension (`quarkus-resteasy-client`),"
-msgstr "a extensão RESTEasy Classic REST Client ( `quarkus-resteasy-client` ),"
+msgstr "a extensão RESTEasy Classic REST Client (`quarkus-resteasy-client`),"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the REST Client extension (`quarkus-rest-client`),"
-msgstr "a extensão do cliente REST ( `quarkus-rest-client` ),"
+msgstr "a extensão REST Client (`quarkus-rest-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the SmallRye GraphQL Client extension (`quarkus-smallrye-graphql-client`),"
-msgstr "a extensão SmallRye GraphQL Client ( `quarkus-smallrye-graphql-client` ),"
+msgstr "a extensão SmallRye GraphQL Client (`quarkus-smallrye-graphql-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Spring Cloud Config client extension (`quarkus-spring-cloud-config-client`),"
-msgstr "a extensão do cliente Spring Cloud Config ( `quarkus-spring-cloud-config-client` ),"
+msgstr "a extensão Spring Cloud Config client (`quarkus-spring-cloud-config-client`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Vault extension (`quarkus-vault`),"
-msgstr "a extensão do Vault ( `quarkus-vault` ),"
+msgstr "a extensão Vault (`quarkus-vault`),"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "the Cassandra client extensions (`cassandra-quarkus-client`)"
-msgstr "as extensões do cliente Cassandra ( `cassandra-quarkus-client` )"
+msgstr "as extensões Cassandra client (`cassandra-quarkus-client`)"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "As long as you have one of these extensions in your project, the SSL support will be enabled by default."
-msgstr "Desde que o senhor tenha uma dessas extensões em seu projeto, o suporte a SSL será ativado por padrão."
+msgstr "Desde que você tenha uma dessas extensões em seu projeto, o suporte a SSL será habilitado por padrão."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "If you are not using any of them and you want to enable SSL support anyway, please add the following to your configuration:"
-msgstr "Se o senhor não estiver usando nenhum deles e quiser habilitar o suporte a SSL de qualquer forma, adicione o seguinte à sua configuração:"
+msgstr "Se você não estiver usando nenhuma delas e quiser habilitar o suporte a SSL mesmo assim, adicione o seguinte à sua configuração:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Now, let's just check the size of our native executable as it will be useful later:"
 msgstr "Agora, vamos apenas verificar o tamanho do nosso executável nativo, pois isso será útil mais tarde:"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy, no-wrap
 msgid "Let's disable SSL and see how it goes"
-msgstr "Vamos desativar o SSL e ver como fica"
+msgstr "Vamos desabilitar o SSL e ver como fica"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "Quarkus has an option to disable the SSL support entirely.\n"
 "Why? Because it comes at a certain cost.\n"
 "So if you are sure you don't need it, you can disable it entirely."
-msgstr "O Quarkus tem uma opção para desativar totalmente o suporte a SSL. Por quê? Porque ele tem um certo custo. Portanto, se o senhor tiver certeza de que não precisa dele, poderá desativá-lo totalmente."
+msgstr ""
+"O Quarkus tem uma opção para desabilitar o suporte a SSL inteiramente.\n"
+"Por quê? Porque ele tem um certo custo.\n"
+"Portanto, se você tiver certeza de que não precisa dele, poderá desabilitá-lo totalmente."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "First, let's disable it without changing the REST service URL and see how it goes."
-msgstr "Primeiro, vamos desativá-lo sem alterar o URL do serviço REST e ver como fica."
+msgstr "Primeiro, vamos desabilitá-lo sem alterar a URL do serviço REST e ver o que acontece."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Open `src/main/resources/application.properties` and add the following line:"
-msgstr "Abra o site `src/main/resources/application.properties` e adicione a seguinte linha:"
+msgstr "Abra `src/main/resources/application.properties` e adicione a seguinte linha:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "And let's try to build again:"
-msgstr "E vamos tentar construir novamente:"
+msgstr "E vamos tentar compilar novamente:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "The native executable tests will fail with the following error:"
-msgstr "Os testes executáveis nativos falharão com o seguinte erro:"
+msgstr "Os testes do executável nativo falharão com o seguinte erro:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "This error is the one you obtain when trying to use SSL while it was not explicitly enabled in your native executable."
-msgstr "Esse erro é o que o senhor obtém ao tentar usar o SSL enquanto ele não estiver explicitamente ativado no executável nativo."
+msgstr "Este erro é o que você obtém ao tentar usar SSL quando ele não foi explicitamente habilitado em seu executável nativo."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Now, let's change the REST service URL to **not** use SSL in `src/main/resources/application.properties`:"
-msgstr "Agora, vamos alterar o URL do serviço REST para *não* usar SSL em `src/main/resources/application.properties` :"
+msgstr "Agora, vamos alterar a URL do serviço REST para **não** usar SSL em `src/main/resources/application.properties`:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "and since http://stage.code.quarkus.io/api responds with 302 status code we need to also skip the tests with `-DskipTests`."
-msgstr "E como http://stage.code.quarkus.io/api responde com o código de status 302, também precisamos ignorar os testes com `-DskipTests` ."
+msgstr "e como http://stage.code.quarkus.io/api responde com o código de status 302, também precisamos pular os testes com `-DskipTests`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Now we can build again:"
-msgstr "Agora podemos construir novamente:"
+msgstr "Agora podemos compilar novamente:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "If you check carefully the native executable build options, you can see that the SSL related options are gone:"
-msgstr "Se o senhor verificar cuidadosamente as opções de compilação do executável nativo, verá que as opções relacionadas ao SSL desapareceram:"
+msgstr "Se você verificar cuidadosamente as opções de compilação do executável nativo, verá que as opções relacionadas ao SSL desapareceram:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "And we end up with:"
-msgstr "E acabamos com isso:"
+msgstr "E terminamos com:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "You remember we checked the size of the native executable with SSL enabled?\n"
 "Let's check again with SSL support entirely disabled:"
-msgstr "O senhor se lembra que verificamos o tamanho do executável nativo com o SSL ativado? Vamos verificar novamente com o suporte a SSL totalmente desativado:"
+msgstr ""
+"Você se lembra que verificamos o tamanho do executável nativo com o SSL habilitado?\n"
+"Vamos verificar novamente com o suporte a SSL totalmente desabilitado:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Yes, it is now **35 MB** whereas it used to be **46 MB**. SSL comes with an 11 MB overhead in native executable size."
-msgstr "Sim, agora são *35 MB* , enquanto antes eram *46 MB* . O SSL vem com uma sobrecarga de 11 MB no tamanho do executável nativo."
+msgstr "Sim, agora são **35 MB**, enquanto antes eram **46 MB**. O SSL traz um overhead de 11 MB no tamanho do executável nativo."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "And there's more to it."
 msgstr "E há mais do que isso."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy, no-wrap
 msgid "Let's start again with a clean slate"
-msgstr "Vamos começar de novo com uma lousa limpa"
+msgstr "Vamos começar de novo do zero"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Let's revert the changes we made to the configuration file and go back to SSL with the following command:"
 msgstr "Vamos reverter as alterações que fizemos no arquivo de configuração e voltar ao SSL com o seguinte comando:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "And let's build the native executable again:"
-msgstr "E vamos criar o executável nativo novamente:"
+msgstr "E vamos compilar o executável nativo novamente:"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy, no-wrap
 msgid "The TrustStore path"
 msgstr "O caminho do TrustStore"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "This section explains how to configure the default trust store when building a native executable.\n"
 "However, it is **strongly recommended** to use the xref:./tls-registry-reference.adoc[TLS registry] instead.\n"
 "The TLS registry ensures a consistent experience and feature set across both JVM and native modes."
-msgstr "Esta seção explica como configurar o trust store padrão ao criar um executável nativo. No entanto, é *altamente recomendável* usar o xref:./tls-registry-reference.adoc[registro TLS] . O registro TLS garante uma experiência consistente e um conjunto de recursos nos modos JVM e nativo."
+msgstr ""
+"Esta seção explica como configurar o trust store padrão ao compilar um executável nativo.\n"
+"No entanto, é **fortemente recomendado** usar o xref:./tls-registry-reference.adoc[registro TLS] em seu lugar.\n"
+"O registro TLS garante uma experiência e um conjunto de recursos consistentes nos modos JVM e nativo."
 
-#. type: Plain text
+#. type: delimited block =
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "This behavior is new to GraalVM 21.3+."
-msgstr "Esse comportamento é novo no GraalVM 21.3+."
+msgstr "Este comportamento é novo no GraalVM 21.3+."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "GraalVM supports both build time and runtime certificate configuration."
-msgstr "O GraalVM oferece suporte à configuração de certificados em tempo de construção e em tempo de execução."
+msgstr "O GraalVM suporta a configuração de certificados tanto em tempo de compilação quanto em tempo de execução."
 
-#. type: Title ==
+#. type: Title ===
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy, no-wrap
 msgid "Build time configuration"
-msgstr "Configuração do tempo de construção"
+msgstr "Configuração em tempo de compilação"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "The build time approach favors the principle of \"immutable security\" where the appropriate certificates are added at build time, and can never be changed afterward.\n"
 "This guarantees that the list of valid certificates cannot be tampered with when the application gets deployed in production."
-msgstr "A abordagem de tempo de compilação favorece o princípio da \"segurança imutável\", em que os certificados apropriados são adicionados no momento da compilação e nunca podem ser alterados posteriormente. Isso garante que a lista de certificados válidos não possa ser adulterada quando o aplicativo for implantado na produção."
+msgstr ""
+"A abordagem em tempo de compilação favorece o princípio de \"segurança imutável\", onde os certificados apropriados são adicionados no momento da compilação e nunca podem ser alterados depois.\n"
+"Isso garante que a lista de certificados válidos não possa ser adulterada quando a aplicação for implantada em produção."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "However, this comes with a few drawbacks:"
-msgstr "No entanto, isso tem algumas desvantagens:"
+msgstr "No entanto, isso traz algumas desvantagens:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "If you use the same executable in all environments, and a certificate expires, the application needs to be rebuilt, and redeployed into production with the new certificate, which is an inconvenience."
-msgstr "Se o senhor usar o mesmo executável em todos os ambientes e um certificado expirar, o aplicativo precisará ser reconstruído e reimplantado na produção com o novo certificado, o que é um inconveniente."
+msgstr "Se você usar o mesmo executável em todos os ambientes e um certificado expirar, a aplicação precisará ser recompilada e implantada novamente em produção com o novo certificado, o que é um inconveniente."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Even worse, if a certificate gets revoked because of a security breach, all applications that embed this certificate need to be rebuilt and redeployed in a timely manner."
-msgstr "Pior ainda, se um certificado for revogado devido a uma violação de segurança, todos os aplicativos que incorporam esse certificado precisam ser reconstruídos e reimplantados em tempo hábil."
+msgstr "Pior ainda, se um certificado for revogado devido a uma falha de segurança, todas as aplicações que incorporam esse certificado precisarão ser recompiladas e implantadas novamente em tempo hábil."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "This requires also to add into the application all certificates for all environments (e.g. `dev`, `test`, `prod`), which means that a certificate that is required for dev mode but should not be used elsewhere, will make its way anyway in production."
-msgstr "Isso também exige que o senhor adicione ao aplicativo todos os certificados para todos os ambientes (por exemplo, `dev` , `test` , `prod` ), o que significa que um certificado necessário para o modo de desenvolvimento, mas que não deve ser usado em nenhum outro lugar, será usado de qualquer forma na produção."
+msgstr "Isso também requer a adição na aplicação de todos os certificados para todos os ambientes (ex: `dev`, `test`, `prod`), o que significa que um certificado necessário para o modo dev, mas que não deve ser usado em outro lugar, acabará indo para a produção de qualquer maneira."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Providing all certificates at build time complicates the CI, specifically in dynamic environments such as Kubernetes where valid certificates are provided by the platform in the `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` PEM file."
-msgstr "Fornecer todos os certificados no momento da compilação complica a CI, especificamente em ambientes dinâmicos como o Kubernetes, em que os certificados válidos são fornecidos pela plataforma no arquivo `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` PEM."
+msgstr "Fornecer todos os certificados no momento da compilação complica o CI, especificamente em ambientes dinâmicos como o Kubernetes, onde certificados válidos são fornecidos pela plataforma no arquivo PEM `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "Lastly, this does not play well with third party software that do not provide a dedicated build for each customer environment."
-msgstr "Por fim, isso não funciona bem com softwares de terceiros que não fornecem uma compilação dedicada para cada ambiente do cliente."
+msgstr "Por fim, isso não funciona bem com softwares de terceiros que não fornecem um build dedicado para cada ambiente de cliente."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "Creating a native executable using build time certificates essentially means that the root certificates are fixed at image build time, based on the certificate configuration used at build time (which for Quarkus means when you perform a build having `quarkus.native.enabled=true` set).\n"
 "This avoids shipping a `cacerts` file or requiring a system property be set in order to set up root certificates that are provided by the OS where the binary runs."
-msgstr "A criação de um executável nativo usando certificados de tempo de compilação significa essencialmente que os certificados raiz são fixados no momento da compilação da imagem, com base na configuração do certificado usada no momento da compilação (o que, para o Quarkus, significa quando o usuário executa uma compilação com `quarkus.native.enabled=true` definido). Isso evita o envio de um arquivo `cacerts` ou a necessidade de definir uma propriedade do sistema para configurar certificados raiz que são fornecidos pelo sistema operacional em que o binário é executado."
+msgstr ""
+"Criar um executável nativo usando certificados em tempo de compilação significa essencialmente que os certificados raiz são fixados no momento da compilação da imagem, com base na configuração de certificado usada na compilação (o que para o Quarkus significa quando você executa um build com `quarkus.native.enabled=true` definido).\n"
+"Isso evita o envio de um arquivo `cacerts` ou a exigência de definir uma propriedade de sistema para configurar os certificados raiz fornecidos pelo SO onde o binário é executado."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "In this situation, system properties such as `javax.net.ssl.trustStore` do not have an effect at\n"
 "run time, so when the defaults need to be changed, these system properties must be provided at image build time.\n"
 "The easiest way to do so is by setting `quarkus.native.additional-build-args`. For example:"
-msgstr "Nessa situação, as propriedades do sistema, como `javax.net.ssl.trustStore` , não têm efeito no momento da execução, portanto, quando os padrões precisam ser alterados, essas propriedades do sistema devem ser fornecidas no momento da criação da imagem. A maneira mais fácil de fazer isso é definir `quarkus.native.additional-build-args` . Por exemplo:"
+msgstr ""
+"Nesta situação, propriedades de sistema como `javax.net.ssl.trustStore` não têm efeito em\n"
+"tempo de execução, portanto, quando os padrões precisam ser alterados, essas propriedades de sistema devem ser fornecidas no momento da compilação da imagem.\n"
+"A maneira mais fácil de fazer isso é definindo `quarkus.native.additional-build-args`. Por exemplo:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "will ensure that the certificates of `/tmp/mycerts` are baked into the native binary and used *instead* of the default `cacerts`.\n"
 "The file containing the custom TrustStore does *not* (and probably should not) have to be present at runtime as its content has been baked into the native binary."
-msgstr "garantirá que os certificados de `/tmp/mycerts` sejam incorporados ao binário nativo e usados *em vez* do padrão `cacerts` . O arquivo que contém o TrustStore personalizado *não* precisa (e provavelmente não deve) estar presente no tempo de execução, pois seu conteúdo foi incorporado ao binário nativo."
+msgstr ""
+"garantirá que os certificados de `/tmp/mycerts` sejam incorporados ao binário nativo e usados *em vez* do `cacerts` padrão.\n"
+"O arquivo que contém o TrustStore personalizado *não* precisa (e provavelmente não deveria) estar presente em tempo de execução, pois seu conteúdo foi incorporado ao binário nativo."
 
-#. type: Title ==
+#. type: Title ===
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy, no-wrap
 msgid "Run time configuration"
-msgstr "Configuração do tempo de execução"
+msgstr "Configuração em tempo de execução"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "Using the runtime certificate configuration, supported by GraalVM since 21.3 does not require any special or additional configuration compared to regular java programs or Quarkus in jvm mode.\n"
 "For more information, see the link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/dynamic-features/CertificateManagement/#runtime-options[Runtime Options] section of the \"GraalVM Certificate Management in Native Image\" guide."
-msgstr "O uso da configuração do certificado de tempo de execução, suportado pelo GraalVM desde a versão 21.3, não requer nenhuma configuração especial ou adicional em comparação com os programas java comuns ou o Quarkus no modo jvm. Para obter mais informações, consulte a seção link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/dynamic-features/CertificateManagement/#runtime-options[Runtime Options] do guia \"GraalVM Certificate Management in Native Image\"."
+msgstr ""
+"O uso da configuração de certificados em tempo de execução, suportada pelo GraalVM desde a versão 21.3, não requer nenhuma configuração especial ou adicional em comparação com programas Java comuns ou Quarkus no modo JVM.\n"
+"Para obter mais informações, consulte a seção link:https://www.graalvm.org/{graalvm-docs-version}/reference-manual/native-image/dynamic-features/CertificateManagement/#runtime-options[Opções de Tempo de Execução] do guia \"Gerenciamento de Certificados GraalVM em Imagem Nativa\"."
 
-#. type: Title ==
+#. type: Title ===
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy, no-wrap
 msgid "Working with containers"
 msgstr "Trabalhando com contêineres"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid ""
 "No special action needs to be taken when running the native binary in a container. If the native binary was properly built with the custom TrustStore\n"
 "as described in the previous section, it will work properly in container as well."
-msgstr "Nenhuma ação especial precisa ser tomada ao executar o binário nativo em um contêiner. Se o binário nativo tiver sido criado corretamente com o TrustStore personalizado, conforme descrito na seção anterior, ele também funcionará corretamente no contêiner."
+msgstr ""
+"Nenhuma ação especial precisa ser tomada ao executar o binário nativo em um contêiner. Se o binário nativo foi compilado corretamente com o TrustStore personalizado\n"
+"conforme descrito na seção anterior, ele também funcionará corretamente em um contêiner."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy, no-wrap
 msgid "Conclusion"
 msgstr "Conclusão"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/native-and-ssl.adoc
 #, fuzzy
 msgid "We make building native executable using SSL easy, and provide several options to cope well with different types of security requirements."
-msgstr "Facilitamos a criação de executáveis nativos usando SSL e oferecemos várias opções para atender a diferentes tipos de requisitos de segurança."
+msgstr "Tornamos fácil a compilação de executáveis nativos usando SSL e fornecemos várias opções para lidar bem com diferentes tipos de requisitos de segurança."

--- a/l10n/po/pt_BR/_guides/smallrye-health.adoc.po
+++ b/l10n/po/pt_BR/_guides/smallrye-health.adoc.po
@@ -9,24 +9,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: YAML Front Matter: title
 #. This guide is maintained in the main Quarkus repository
 #. and pull requests should be submitted there:
 #. https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+#. type: Title =
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "SmallRye Health"
-msgstr "Saúde SmallRye"
+msgstr "SmallRye Health"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "This guide demonstrates how your Quarkus application can use https://github.com/smallrye/smallrye-health/[SmallRye Health]\n"
 "an implementation of the https://github.com/eclipse/microprofile-health/[MicroProfile Health] specification."
-msgstr "Este guia demonstra como o seu aplicativo Quarkus pode usar o link:https://github.com/smallrye/smallrye-health/[SmallRye Health] como uma implementação da especificação link:https://github.com/eclipse/microprofile-health/[MicroProfile Health] ."
+msgstr ""
+"Este guia demonstra como sua aplicação Quarkus pode usar https://github.com/smallrye/smallrye-health/[SmallRye Health]\n"
+"uma implementação da especificação https://github.com/eclipse/microprofile-health/[MicroProfile Health]."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -34,204 +37,252 @@ msgid ""
 "to external viewers which is typically useful in cloud environments where automated\n"
 "processes must be able to determine whether the application should be discarded\n"
 "or restarted."
-msgstr "O SmallRye Health permite que os aplicativos forneçam informações sobre seu estado para visualizadores externos, o que normalmente é útil em ambientes de nuvem em que os processos automatizados devem ser capazes de determinar se o aplicativo deve ser descartado ou reiniciado."
+msgstr ""
+"O SmallRye Health permite que as aplicações forneçam informações sobre seu estado\n"
+"a visualizadores externos, o que é tipicamente útil em ambientes de nuvem onde processos\n"
+"automatizados devem ser capazes de determinar se a aplicação deve ser descartada\n"
+"ou reiniciada."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Prerequisites"
 msgstr "Pré-requisitos"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Architecture"
 msgstr "Arquitetura"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "In this guide, we build a simple REST application that exposes MicroProfile Health\n"
 "functionalities at the `/q/health/live` and `/q/health/ready` endpoints according to the\n"
 "specification."
-msgstr "Neste guia, criamos um aplicativo REST simples que expõe as funcionalidades do MicroProfile Health nos pontos de extremidade `/q/health/live` e `/q/health/ready` de acordo com a especificação."
+msgstr ""
+"Neste guia, criamos uma aplicação REST simples que expõe as funcionalidades do MicroProfile Health\n"
+"nos endpoints `/q/health/live` e `/q/health/ready` de acordo com a\n"
+"especificação."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Solution"
 msgstr "Solução"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
+#, fuzzy
 msgid ""
 "We recommend that you follow the instructions in the next sections and create the\n"
 "application step by step. However, you can go right to the completed example."
-msgstr "Recomendamos que siga as instruções nas seções seguintes e crie a aplicação passo a passo. No entanto, você pode ir diretamente para o exemplo completo."
+msgstr ""
+"Recomendamos que você siga as instruções nas próximas seções e crie a\n"
+"aplicação passo a passo. No entanto, você pode ir diretamente para o exemplo concluído."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
+#, fuzzy
 msgid ""
 "Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an\n"
 "{quickstarts-archive-url}[archive]."
-msgstr "Clone o repositório Git: `git clone {quickstarts-clone-url}`, ou baixe um {quickstarts-archive-url}[arquivo]."
+msgstr ""
+"Clone o repositório Git: `git clone {quickstarts-clone-url}`, ou baixe um\n"
+"{quickstarts-archive-url}[arquivo]."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "The solution is located in the `microprofile-health-quickstart`\n"
 "{quickstarts-tree-url}/microprofile-health-quickstart[directory]."
-msgstr "A solução está localizada em `microprofile-health-quickstart` {quickstarts-tree-url}/microprofile-health-quickstart[directory]."
+msgstr ""
+"A solução está localizada no {quickstarts-tree-url}/microprofile-health-quickstart[diretório]\n"
+"`microprofile-health-quickstart`."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Creating the Maven Project"
-msgstr "Criando o projeto Maven"
+msgstr "Criando o Projeto Maven"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
+#, fuzzy
 msgid "First, we need a new project. Create a new project with the following command:"
 msgstr "Primeiro, precisamos de um novo projeto. Crie um novo projeto com o seguinte comando:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "This command generates a project, importing the `smallrye-health` extension."
-msgstr "Esse comando gera um projeto, importando a extensão `smallrye-health` ."
+msgstr "Este comando gera um projeto, importando a extensão `smallrye-health`."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "If you already have your Quarkus project configured, you can add the `smallrye-health` extension\n"
 "to your project by running the following command in your project base directory:"
-msgstr "Se já tiver o projeto Quarkus configurado, o senhor pode adicionar a extensão `smallrye-health` ao projeto executando o seguinte comando no diretório base do projeto:"
+msgstr ""
+"Se você já tem seu projeto Quarkus configurado, você pode adicionar a extensão `smallrye-health` \n"
+"ao seu projeto executando o seguinte comando no diretório base do projeto:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
+#, fuzzy
 msgid "This will add the following to your build file:"
-msgstr "Isto irá adicionar o seguinte trecho no seu arquivo de build:"
+msgstr "Isso adicionará o seguinte ao seu arquivo de build:"
 
 #. type: Block title
+#. mt: gemini
 #: _guides/smallrye-health.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "pom.xml"
 msgstr "pom.xml"
 
 #. type: Block title
+#. mt: gemini
 #: _guides/smallrye-health.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "build.gradle"
 msgstr "build.gradle"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Running the health check"
-msgstr "Execução do exame de saúde"
+msgstr "Executando o health check"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Importing the `smallrye-health` extension directly exposes three REST endpoints:"
-msgstr "A importação da extensão `smallrye-health` expõe diretamente três pontos de extremidade REST:"
+msgstr "A importação da extensão `smallrye-health` expõe diretamente três endpoints REST:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`/q/health/live` - The application is up and running."
-msgstr "`/q/health/live` - O aplicativo está em funcionamento."
+msgstr "`/q/health/live` - A aplicação está ativa e em execução."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`/q/health/ready` - The application is ready to serve requests."
-msgstr "`/q/health/ready` - O aplicativo está pronto para atender às solicitações."
+msgstr "`/q/health/ready` - A aplicação está pronta para atender requisições."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`/q/health/started` - The application is started."
-msgstr "`/q/health/started` - O aplicativo é iniciado."
+msgstr "`/q/health/started` - A aplicação foi iniciada."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`/q/health` - Accumulating all health check procedures in the application."
-msgstr "`/q/health` - Acumular todos os procedimentos de verificação de saúde no aplicativo."
+msgstr "`/q/health` - Acumulando todos os procedimentos de verificação de saúde na aplicação."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "To check that the `smallrye-health` extension is working as expected:"
-msgstr "Para verificar se a extensão `smallrye-health` está funcionando conforme o esperado:"
+msgstr "Para verificar se a extensão `smallrye-health` está funcionando como esperado:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "start your Quarkus application with:"
-msgstr "inicie seu aplicativo Quarkus com:"
+msgstr "inicie sua aplicação Quarkus com:"
 
-#. type: Block title
+#. mt: gemini
 #: _guides/smallrye-health.adoc
+#, fuzzy
 msgid "CLI"
 msgstr "CLI"
 
-#. type: Block title
+#. mt: gemini
 #: _guides/smallrye-health.adoc
+#, fuzzy
 msgid "Maven"
 msgstr "Maven"
 
-#. type: Block title
+#. mt: gemini
 #: _guides/smallrye-health.adoc
+#, fuzzy
 msgid "Gradle"
 msgstr "Gradle"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "access the `http://localhost:8080/q/health/live` endpoint using your browser or\n"
 "`curl http://localhost:8080/q/health/live`"
-msgstr "acesse o `http://localhost:8080/q/health/live` usando seu navegador ou `curl http://localhost:8080/q/health/live`"
+msgstr ""
+"acesse o endpoint `http://localhost:8080/q/health/live` usando seu navegador ou\n"
+"`curl http://localhost:8080/q/health/live`"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "All `health` REST endpoints return a simple JSON object with two fields:"
-msgstr "Todos os endpoints `health` REST retornam um objeto JSON simples com dois campos:"
+msgstr "Todos os endpoints REST de `health` retornam um objeto JSON simples com dois campos:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`status` -- the overall result of all the health check procedures"
-msgstr "`status` - o resultado geral de todos os procedimentos do exame de saúde"
+msgstr "`status` -- o resultado geral de todos os procedimentos de verificação de saúde"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`checks` -- an array of individual checks"
-msgstr "`checks` - uma matriz de verificações individuais"
+msgstr "`checks` -- um array de verificações individuais"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "The general `status` of the health check is computed as a logical AND of all the\n"
 "declared health check procedures. The `checks` array is empty as we have not specified\n"
 "any health check procedure yet so let's define some."
-msgstr "O `status` geral do exame de saúde é calculado como um AND lógico de todos os procedimentos de exame de saúde declarados. A matriz `checks` está vazia porque ainda não especificamos nenhum procedimento de verificação de saúde, portanto, vamos definir alguns."
+msgstr ""
+"O `status` geral da verificação de saúde é calculado como um AND lógico de todos os\n"
+"procedimentos de verificação de saúde declarados. O array `checks` está vazio, pois não especificamos\n"
+"nenhum procedimento de verificação de saúde ainda, então vamos definir alguns."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Management interface"
 msgstr "Interface de gerenciamento"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -239,66 +290,81 @@ msgid ""
 "You can expose them on a separate network interface and port by enabling the management interface with the\n"
 "`quarkus.management.enabled=true` property.\n"
 "Refer to the xref:./management-interface-reference.adoc[management interface reference] for more information."
-msgstr "Por padrão, as verificações de integridade são expostas no servidor HTTP principal. O senhor pode expô-los em uma interface de rede e porta separadas, ativando a interface de gerenciamento com a propriedade `quarkus.management.enabled=true` . Para obter mais informações, consulte a xref:./management-interface-reference.adoc[referência da interface de gerenciamento] ."
+msgstr ""
+"Por padrão, os health checks são expostos no servidor HTTP principal.\n"
+"Você pode expô-los em uma interface de rede e porta separadas ativando a interface de gerenciamento com a\n"
+"propriedade `quarkus.management.enabled=true`.\n"
+"Consulte a xref:./management-interface-reference.adoc[referência da interface de gerenciamento] para mais informações."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Creating your first health check"
-msgstr "Criando seu primeiro exame de saúde"
+msgstr "Criando seu primeiro health check"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "In this section, we create our first simple health check procedure."
-msgstr "Nesta seção, criamos nosso primeiro procedimento simples de verificação de integridade."
+msgstr "Nesta seção, criamos nosso primeiro procedimento simples de verificação de saúde."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Create the `org.acme.microprofile.health.SimpleHealthCheck` class:"
-msgstr "Crie a classe `org.acme.microprofile.health.SimpleHealthCheck` :"
+msgstr "Crie a classe `org.acme.microprofile.health.SimpleHealthCheck`:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "It's recommended to annotate the health check class with `@ApplicationScoped` or the `@Singleton` scope so that a single bean instance is used for all health check requests."
-msgstr "Recomenda-se anotar a classe de verificação de integridade com `@ApplicationScoped` ou o escopo `@Singleton` para que uma única instância de bean seja usada para todas as solicitações de verificação de integridade."
+msgstr "É recomendado anotar a classe de health check com o escopo `@ApplicationScoped` ou `@Singleton` para que uma única instância de bean seja usada para todas as requisições de verificação de saúde."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "If a bean class annotated with one of the health check annotations declares no scope then the `@Singleton` scope is used automatically."
-msgstr "Se uma classe bean anotada com uma das anotações de verificação de integridade não declarar nenhum escopo, o escopo `@Singleton` será usado automaticamente."
+msgstr "Se uma classe bean anotada com uma das anotações de health check não declarar nenhum escopo, o escopo `@Singleton` será usado automaticamente."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "As you can see, the health check procedures are defined as CDI beans that implement the `HealthCheck` interface and are annotated with one of the health check qualifiers, such as:"
-msgstr "Como o senhor pode ver, os procedimentos de verificação de integridade são definidos como beans CDI que implementam a interface `HealthCheck` e são anotados com um dos qualificadores de verificação de integridade, como"
+msgstr "Como você pode ver, os procedimentos de health check são definidos como beans CDI que implementam a interface `HealthCheck` e são anotados com um dos qualificadores de health check, como:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`@Liveness` - the liveness check accessible at `/q/health/live`"
-msgstr "`@Liveness` - a verificação de vivacidade acessível em `/q/health/live`"
+msgstr "`@Liveness` - a verificação de liveness acessível em `/q/health/live`"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`@Readiness` - the readiness check accessible at `/q/health/ready`"
-msgstr "`@Readiness` - A verificação de prontidão pode ser acessada em `/q/health/ready`"
+msgstr "`@Readiness` - a verificação de readiness acessível em `/q/health/ready`"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "`HealthCheck` is a functional interface whose single method `call` returns a\n"
 "`HealthCheckResponse` object which can be easily constructed by the fluent builder\n"
 "API shown in the example."
-msgstr "`HealthCheck` é uma interface funcional cujo único método `call` retorna um objeto `HealthCheckResponse` que pode ser facilmente construído pela API do construtor fluente mostrada no exemplo."
+msgstr ""
+"`HealthCheck` é uma interface funcional cujo único método `call` retorna um\n"
+"objeto `HealthCheckResponse` que pode ser facilmente construído pela API\n"
+"fluent builder mostrada no exemplo."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -307,23 +373,31 @@ msgid ""
 "using `curl http://localhost:8080/q/health/live`. Because we defined our health check\n"
 "to be a liveness procedure (with `@Liveness` qualifier) the new health check procedure\n"
 "is now present in the `checks` array."
-msgstr "Como iniciamos nosso aplicativo Quarkus no modo de desenvolvimento, basta repetir a solicitação para `http://localhost:8080/q/health/live` atualizando a janela do navegador ou usando `curl http://localhost:8080/q/health/live` . Como definimos nossa verificação de integridade como um procedimento de vivacidade (com o qualificador `@Liveness` ), o novo procedimento de verificação de integridade agora está presente na matriz `checks` ."
+msgstr ""
+"Como iniciamos nossa aplicação Quarkus em modo dev, basta repetir a requisição\n"
+"para `http://localhost:8080/q/health/live` atualizando a janela do seu navegador ou\n"
+"usando `curl http://localhost:8080/q/health/live`. Como definimos nosso health check\n"
+"para ser um procedimento de liveness (com o qualificador `@Liveness`), o novo procedimento de verificação de saúde\n"
+"agora está presente no array `checks`."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "Congratulations! You've created your first Quarkus health check procedure. Let's\n"
 "continue by exploring what else can be done with SmallRye Health."
-msgstr "Parabéns! O senhor criou seu primeiro procedimento de verificação de integridade do Quarkus. Vamos continuar explorando o que mais pode ser feito com o SmallRye Health."
+msgstr ""
+"Parabéns! Você criou seu primeiro procedimento de verificação de saúde do Quarkus. Vamos\n"
+"continuar explorando o que mais pode ser feito com o SmallRye Health."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Adding a readiness health check procedure"
-msgstr "Adição de um procedimento de verificação da prontidão"
+msgstr "Adicionando um procedimento de verificação de saúde de prontidão (readiness)"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -331,24 +405,32 @@ msgid ""
 "whether our application is running or not. In this section, we will create a readiness\n"
 "health check which will be able to state whether our application is able to process\n"
 "requests."
-msgstr "Na seção anterior, criamos um procedimento simples de verificação de integridade de vivacidade que informa se o nosso aplicativo está em execução ou não. Nesta seção, criaremos uma verificação de integridade de prontidão que poderá indicar se o nosso aplicativo é capaz de processar solicitações."
+msgstr ""
+"Na seção anterior, criamos um procedimento simples de verificação de saúde de liveness que indica\n"
+"se nossa aplicação está em execução ou não. Nesta seção, criaremos uma verificação de saúde\n"
+"de prontidão (readiness) que será capaz de informar se nossa aplicação é capaz de processar\n"
+"requisições."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "We will create another health check procedure that simulates a connection to\n"
 "an external service provider such as a database. For starters, we will always return\n"
 "the response indicating the application is ready."
-msgstr "Criaremos outro procedimento de verificação de integridade que simula uma conexão com um provedor de serviços externo, como um banco de dados. Para começar, sempre retornaremos a resposta indicando que o aplicativo está pronto."
+msgstr ""
+"Criaremos outro procedimento de verificação de saúde que simula uma conexão com\n"
+"um provedor de serviços externo, como um banco de dados. Para começar, sempre retornaremos\n"
+"a resposta indicando que a aplicação está pronta."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Create `org.acme.microprofile.health.DatabaseConnectionHealthCheck` class:"
-msgstr "Criar a classe `org.acme.microprofile.health.DatabaseConnectionHealthCheck` :"
+msgstr "Crie a classe `org.acme.microprofile.health.DatabaseConnectionHealthCheck`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -359,15 +441,16 @@ msgid ""
 "`curl http://localhost:8080/q/health/ready`) you will see only the\n"
 "`Database connection health check` as it is the only health check defined with the\n"
 "`@Readiness` qualifier as the readiness health check procedure."
-msgstr "Se agora o senhor executar novamente a verificação de integridade em `http://localhost:8080/q/health/live` a matriz `checks` conterá apenas o `SimpleHealthCheck` definido anteriormente, pois é a única verificação definida com o qualificador `@Liveness` . No entanto, se o senhor acessar `http://localhost:8080/q/health/ready` (no navegador ou com `curl http://localhost:8080/q/health/ready` ), o senhor verá apenas o `Database connection health check` , pois é a única verificação de integridade definida com o qualificador `@Readiness` como o procedimento de verificação de integridade de prontidão."
+msgstr "Se você executar novamente a verificação de saúde em `http://localhost:8080/q/health/live`, o array `checks` conterá apenas o `SimpleHealthCheck` definido anteriormente, pois é a única verificação definida com o qualificador `@Liveness`. No entanto, se você acessar `http://localhost:8080/q/health/ready` (no navegador ou com `curl http://localhost:8080/q/health/ready`), verá apenas o `Database connection health check`, pois é a única verificação de saúde definida com o qualificador `@Readiness` como o procedimento de verificação de prontidão."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "If you access `http://localhost:8080/q/health` you will get back both checks."
-msgstr "Se o senhor acessar `http://localhost:8080/q/health` o senhor receberá de volta os dois cheques."
+msgstr "Se você acessar `http://localhost:8080/q/health`, receberá ambas as verificações."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -375,45 +458,51 @@ msgid ""
 "is detailed in the MicroProfile Health specification. Generally, the liveness\n"
 "procedures determine whether the application should be restarted while readiness\n"
 "procedures determine whether it makes sense to contact the application with requests."
-msgstr "Mais informações sobre quais procedimentos de verificação de integridade devem ser usados em cada situação estão detalhadas na especificação MicroProfile Health. Em geral, os procedimentos de vivacidade determinam se o aplicativo deve ser reiniciado, enquanto os procedimentos de prontidão determinam se faz sentido contatar o aplicativo com solicitações."
+msgstr "Mais informações sobre quais procedimentos de verificação de saúde devem ser usados em cada situação são detalhadas na especificação MicroProfile Health. Geralmente, os procedimentos de liveness determinam se a aplicação deve ser reiniciada, enquanto os procedimentos de readiness determinam se faz sentido contatar a aplicação com requisições."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Adding a startup health check procedure"
-msgstr "Adição de um procedimento de verificação de integridade de inicialização"
+msgstr "Adicionando um procedimento de verificação de saúde de inicialização"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "The third and final type of health check procedures is startup. Startup procedures are defined as an option for slow starting containers (should not be needed in Quarkus) to delay the invocations of liveness probe which will take over from startup once the startup responds UP for the first time. Startup health checks are defined with the `@Startup` qualifier."
-msgstr "O terceiro e último tipo de procedimento de verificação de integridade é a inicialização. Os procedimentos de inicialização são definidos como uma opção para contêineres de inicialização lenta (não devem ser necessários no Quarkus) para atrasar as invocações da sonda de vivacidade que assumirá a inicialização assim que a inicialização responder UP pela primeira vez. As verificações de integridade da inicialização são definidas com o qualificador `@Startup` ."
+msgstr "O terceiro e último tipo de procedimento de verificação de saúde é o de inicialização (startup). Os procedimentos de inicialização são definidos como uma opção para containers de inicialização lenta (não deve ser necessário no Quarkus) para atrasar as invocações da sonda de liveness, que assumirá o controle a partir da inicialização assim que a inicialização responder UP pela primeira vez. As verificações de saúde de inicialização são definidas com o qualificador `@Startup`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Please make sure that you import the microprofile `org.eclipse.microprofile.health.Startup` annotation since there is an unfortunate clash with `io.quarkus.runtime.Startup`."
-msgstr "Certifique-se de que o senhor importe a anotação do microperfil `org.eclipse.microprofile.health.Startup` , pois há um conflito infeliz com `io.quarkus.runtime.Startup` ."
+msgstr "Certifique-se de importar a anotação microprofile `org.eclipse.microprofile.health.Startup`, pois há um conflito infeliz com `io.quarkus.runtime.Startup`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Create `org.acme.microprofile.health.StartupHealthCheck` class:"
-msgstr "Crie a classe `org.acme.microprofile.health.StartupHealthCheck` :"
+msgstr "Crie a classe `org.acme.microprofile.health.StartupHealthCheck`:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "The startup health check will be available either at `http://localhost:8080/q/health/started` or together with other health check procedure at `http://localhost:8080/q/health`."
-msgstr "O exame de saúde de inicialização estará disponível em `http://localhost:8080/q/health/started` ou junto com outro procedimento de verificação de integridade em `http://localhost:8080/q/health` ."
+msgstr "A verificação de saúde de inicialização estará disponível em `http://localhost:8080/q/health/started` ou junto com outros procedimentos de verificação de saúde em `http://localhost:8080/q/health`."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Negative health check procedures"
-msgstr "Procedimentos de verificação negativa da saúde"
+msgstr "Procedimentos de verificação de saúde negativos"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -421,15 +510,16 @@ msgid ""
 "stating that our application is not ready to process requests as the underlying\n"
 "database connection cannot be established. For simplicity reasons, we only determine\n"
 "whether the database is accessible or not by a configuration property."
-msgstr "Nesta seção, ampliamos nosso site `Database connection health check` com a opção de informar que nosso aplicativo não está pronto para processar solicitações porque a conexão com o banco de dados subjacente não pode ser estabelecida. Por motivos de simplicidade, só determinamos se o banco de dados está acessível ou não por meio de uma propriedade de configuração."
+msgstr "Nesta seção, estendemos nosso `Database connection health check` com a opção de declarar que nossa aplicação não está pronta para processar requisições, pois a conexão com o banco de dados subjacente não pode ser estabelecida. Por questões de simplicidade, determinamos se o banco de dados está acessível ou não apenas por uma propriedade de configuração."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Update the `org.acme.microprofile.health.DatabaseConnectionHealthCheck` class:"
-msgstr "Atualize a classe `org.acme.microprofile.health.DatabaseConnectionHealthCheck` :"
+msgstr "Atualize a classe `org.acme.microprofile.health.DatabaseConnectionHealthCheck`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -438,9 +528,9 @@ msgid ""
 "`HealthCheckResponse#down(String)`) which will directly build the response object.\n"
 "From now on, we utilize the full builder capabilities provided by the\n"
 "`HealthCheckResponseBuilder` class."
-msgstr "Até agora, usamos um método simplificado de criar um `HealthCheckResponse` por meio do `HealthCheckResponse#up(String)` (há também o `HealthCheckResponse#down(String)` ), que criará diretamente o objeto de resposta. A partir de agora, utilizaremos os recursos completos de criação fornecidos pela classe `HealthCheckResponseBuilder` ."
+msgstr "Até agora, usamos um método simplificado de construção de um `HealthCheckResponse` através do `HealthCheckResponse#up(String)` (também existe o `HealthCheckResponse#down(String)`), que constrói diretamente o objeto de resposta. De agora em diante, utilizaremos todos os recursos do builder fornecidos pela classe `HealthCheckResponseBuilder`."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -448,9 +538,9 @@ msgid ""
 "the overall `status` should be DOWN. You can also check the liveness check at\n"
 "`http://localhost:8080/q/health/live` which will return the overall `status` UP because\n"
 "it isn't influenced by the readiness checks."
-msgstr "Se o senhor executar novamente a verificação de integridade de prontidão (em `http://localhost:8080/q/health/ready` ), o site `status` deverá estar ABAIXO. O senhor também pode verificar a verificação de vivacidade em `http://localhost:8080/q/health/live` que retornará o `status` geral ACIMA porque não é influenciado pelas verificações de prontidão."
+msgstr "Se você executar novamente a verificação de saúde de prontidão (em `http://localhost:8080/q/health/ready`), o `status` geral deve ser DOWN. Você também pode verificar a verificação de liveness em `http://localhost:8080/q/health/live`, que retornará o `status` geral UP porque não é influenciado pelas verificações de prontidão."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -458,15 +548,16 @@ msgid ""
 "because we are running Quarkus in dev mode you can add `database.up=true` in\n"
 "`src/main/resources/application.properties` and rerun the readiness health check again\n"
 "-- it should be up again."
-msgstr "Como não devemos deixar esse aplicativo com uma verificação de prontidão em estado DOWN e como estamos executando o Quarkus no modo de desenvolvimento, o senhor pode adicionar `database.up=true` em `src/main/resources/application.properties` e executar novamente a verificação de integridade da prontidão - ela deve estar ativa novamente."
+msgstr "Como não devemos deixar esta aplicação com uma verificação de prontidão em estado DOWN e porque estamos executando o Quarkus em modo dev, você pode adicionar `database.up=true` em `src/main/resources/application.properties` e executar novamente a verificação de prontidão -- ela deve estar UP novamente."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Adding user-specific data to the health check response"
-msgstr "Adição de dados específicos do usuário à resposta do exame de saúde"
+msgstr "Adicionando dados específicos do usuário à resposta da verificação de saúde"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -476,15 +567,16 @@ msgid ""
 "arbitrary data in the form of key-value pairs sent to the consuming end. This can be\n"
 "done by using the `withData(key, value)` method of the health check response\n"
 "builder API."
-msgstr "Nas seções anteriores, vimos como criar health checks simples com apenas os atributos mínimos, ou seja, o nome do health check e seu status (UP ou DOWN). Entretanto, a especificação MicroProfile Health também oferece uma maneira de os aplicativos fornecerem dados arbitrários na forma de pares de valores-chave enviados ao consumidor final. Isso pode ser feito usando o método `withData(key, value)` da API do construtor de respostas de exames de saúde."
+msgstr "Nas seções anteriores, vimos como criar verificações de saúde simples apenas com os atributos mínimos, ou seja, o nome da verificação de saúde e seu status (UP ou DOWN). No entanto, a especificação MicroProfile Health também fornece uma maneira para as aplicações fornecerem dados arbitrários na forma de pares chave-valor enviados para a extremidade consumidora. Isso pode ser feito usando o método `withData(key, value)` da API do builder de resposta de verificação de saúde."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Let's create a new health check procedure `org.acme.microprofile.health.DataHealthCheck`:"
-msgstr "Vamos criar um novo procedimento de verificação de saúde `org.acme.microprofile.health.DataHealthCheck` :"
+msgstr "Vamos criar um novo procedimento de verificação de saúde `org.acme.microprofile.health.DataHealthCheck`:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -492,69 +584,74 @@ msgid ""
 "endpoint you can see that the new health check `Health check with data` is present\n"
 "in the `checks` array. This check contains a new attribute called `data` which is a\n"
 "JSON object consisting of the properties we have defined in our health check procedure."
-msgstr "Se o senhor executar novamente o procedimento de verificação de integridade de vivacidade acessando o endpoint `/q/health/live` , poderá ver que a nova verificação de integridade `Health check with data` está presente na matriz `checks` . Essa verificação contém um novo atributo chamado `data` , que é um objeto JSON que consiste nas propriedades que definimos em nosso procedimento de verificação de integridade."
+msgstr "Se você executar novamente o procedimento de verificação de saúde de liveness acessando o endpoint `/q/health/live`, poderá ver que a nova verificação de saúde `Health check with data` está presente no array `checks`. Esta verificação contém um novo atributo chamado `data`, que é um objeto JSON composto pelas propriedades que definimos em nosso procedimento de verificação de saúde."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "This functionality is specifically useful in failure scenarios where you can pass the\n"
 "error along with the health check response."
-msgstr "Essa funcionalidade é útil especificamente em cenários de falha em que o senhor pode passar o erro junto com a resposta da verificação de integridade."
+msgstr "Esta funcionalidade é especificamente útil em cenários de falha, onde você pode passar o erro junto com a resposta da verificação de saúde."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Context propagation into the health check invocations"
-msgstr "Propagação de contexto nas invocações de verificação de integridade"
+msgstr "Propagação de contexto nas invocações de verificação de saúde"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "For performance reasons, the context (e.g., CDI or security context) is not propagated into each health check invocation. However, if you need to enable this functionality you can set the config property `quarkus.smallrye-health.context-propagation=true` to allow the context propagation into every health check call."
-msgstr "Por motivos de desempenho, o contexto (por exemplo, CDI ou contexto de segurança) não é propagado em cada invocação de verificação de integridade. No entanto, se o senhor precisar ativar essa funcionalidade, poderá definir a propriedade de configuração `quarkus.smallrye-health.context-propagation=true` para permitir a propagação do contexto em cada chamada de verificação de integridade."
+msgstr "Por razões de desempenho, o contexto (por exemplo, CDI ou contexto de segurança) não é propagado para cada invocação de verificação de saúde. No entanto, se você precisar habilitar essa funcionalidade, pode definir a propriedade de configuração `quarkus.smallrye-health.context-propagation=true` para permitir a propagação de contexto em cada chamada de verificação de saúde."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Reactive health checks"
-msgstr "Verificações reativas de saúde"
+msgstr "Verificações de saúde reativas"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "MicroProfile Health currently doesn't support returning reactive types, but SmallRye Health does."
-msgstr "Atualmente, o MicroProfile Health não oferece suporte ao retorno de tipos reativos, mas o SmallRye Health oferece."
+msgstr "O MicroProfile Health atualmente não suporta o retorno de tipos reativos, mas o SmallRye Health sim."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "If you want to provide a reactive health check, you can implement the `io.smallrye.health.api.AsyncHealthCheck` interface instead of the `org.eclipse.microprofile.health.HealthCheck` one.\n"
 "The `io.smallrye.health.api.AsyncHealthCheck` interface allows you to return a `Uni<HealthCheckResponse>`."
-msgstr "Se quiser fornecer uma verificação de integridade reativa, o senhor pode implementar a interface `io.smallrye.health.api.AsyncHealthCheck` em vez da `org.eclipse.microprofile.health.HealthCheck` . A interface `io.smallrye.health.api.AsyncHealthCheck` permite que o senhor retorne um `Uni<HealthCheckResponse>` ."
+msgstr "Se você quiser fornecer uma verificação de saúde reativa, pode implementar a interface `io.smallrye.health.api.AsyncHealthCheck` em vez da interface `org.eclipse.microprofile.health.HealthCheck`. A interface `io.smallrye.health.api.AsyncHealthCheck` permite que você retorne um `Uni<HealthCheckResponse>`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "The following example shows a reactive liveness check:"
-msgstr "O exemplo a seguir mostra uma verificação reativa de vivacidade:"
+msgstr "O exemplo a seguir mostra uma verificação de liveness reativa:"
 
-#. type: Title =
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Health status change observers"
-msgstr "Observadores de mudanças no estado de saúde"
+msgstr "Observadores de mudança de status de saúde"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "If you need to react to change of the health status of your application, the Smallrye Health\n"
 "extension provides a CDI event that can notify you about the individual health status changes."
-msgstr "Se o senhor precisar reagir a mudanças no estado de saúde do seu aplicativo, a extensão Smallrye Health oferece um evento CDI que pode notificá-lo sobre as mudanças individuais no estado de saúde."
+msgstr "Se você precisar reagir à mudança do status de saúde da sua aplicação, a extensão Smallrye Health fornece um evento CDI que pode notificá-lo sobre as mudanças individuais no status de saúde."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -562,71 +659,80 @@ msgid ""
 "with the standard CDI observation mechanism. Since we cannot guarantee that the observer method\n"
 "runs all the time on the worker thread (meaning it can run on the event loop thread), it's\n"
 "recommended that you never block in the in observer method."
-msgstr "Para observar a alteração do status de integridade, o senhor pode observar o site `io.smallrye.health.api.event.HealthStatusChangeEvent` com o mecanismo de observação padrão do CDI. Como não podemos garantir que o método do observador seja executado o tempo todo no thread de trabalho (o que significa que ele pode ser executado no thread do loop de eventos), é recomendável que o senhor nunca bloqueie o método do observador."
+msgstr "Para observar a mudança de status de saúde, você pode observar o `io.smallrye.health.api.event.HealthStatusChangeEvent` com o mecanismo padrão de observação CDI. Como não podemos garantir que o método observador seja executado o tempo todo na thread de worker (o que significa que ele pode ser executado na thread do event loop), recomenda-se que você nunca bloqueie no método observador."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Extension health checks"
-msgstr "Verificações de saúde da extensão"
+msgstr "Verificações de saúde de extensões"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Some extension may provide default health checks, including the extension will automatically register its health checks."
-msgstr "Algumas extensões podem fornecer verificações de integridade padrão, inclusive a extensão registrará automaticamente suas verificações de integridade."
+msgstr "Algumas extensões podem fornecer verificações de saúde padrão; incluir a extensão registrará automaticamente suas verificações de saúde."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "For example, `quarkus-agroal` that is used to manage Quarkus datasource(s) automatically register a readiness health check\n"
 "that will validate each datasource: xref:datasource.adoc#datasource-health-check[Datasource Health Check]."
-msgstr "Por exemplo, o site `quarkus-agroal` , que é usado para gerenciar os recursos de dados do Quarkus, registra automaticamente uma verificação de integridade de prontidão que validará cada recurso de dados: xref:datasource.adoc#datasource-health-check[Datasource Health Check] ."
+msgstr "Por exemplo, o `quarkus-agroal` que é usado para gerenciar datasource(s) do Quarkus registra automaticamente uma verificação de saúde de prontidão que validará cada datasource: xref:datasource.adoc#datasource-health-check[Verificação de Saúde de Datasource]."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "You can disable extension health checks via the property `quarkus.health.extensions.enabled` so none will be automatically registered."
-msgstr "O senhor pode desativar as verificações de integridade da extensão por meio da propriedade `quarkus.health.extensions.enabled` para que nenhuma seja registrada automaticamente."
+msgstr "Você pode desativar as verificações de saúde das extensões via propriedade `quarkus.health.extensions.enabled` para que nenhuma seja registrada automaticamente."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Health UI"
-msgstr "Saúde UI"
+msgstr "Interface de Saúde (Health UI)"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Experimental - not included in the MicroProfile specification"
-msgstr "Experimental - não incluído na especificação do MicroProfile"
+msgstr "Experimental - não incluído na especificação MicroProfile"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`health-ui` allows you to see your Health Checks in a Web GUI."
-msgstr "`health-ui` permite que o senhor veja seus Health Checks em uma GUI da Web."
+msgstr "`health-ui` permite que você veja suas Verificações de Saúde em uma GUI Web."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "The Quarkus `smallrye-health` extension ships with `health-ui` and enables it by default in dev and test modes, but it can also be explicitly configured for production mode as well."
-msgstr "A extensão do Quarkus `smallrye-health` vem com o `health-ui` e o habilita por padrão nos modos de desenvolvimento e teste, mas também pode ser configurada explicitamente para o modo de produção."
+msgstr "A extensão `smallrye-health` do Quarkus vem com o `health-ui` e o habilita por padrão nos modos dev e test, mas também pode ser configurado explicitamente para o modo de produção."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "`health-ui` can be accessed from http://localhost:8080/q/health-ui/ ."
-msgstr "`health-ui` pode ser acessado em http://localhost:8080/q/health-ui/ ."
+msgstr "O `health-ui` pode ser acessado em http://localhost:8080/q/health-ui/ ."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "image:health-ui-screenshot01.png[alt=Health UI]"
-msgstr "image:health-ui-screenshot01.png[alt=\"Health UI\"]"
+msgstr "image:health-ui-screenshot01.png[alt=Health UI]"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -634,29 +740,31 @@ msgid ""
 "You can expose them on a separate network interface and port by setting `quarkus.management.enabled=true` in your application configuration.\n"
 "Note that this property is a build-time property.\n"
 "The value cannot be overridden at runtime."
-msgstr "Por padrão, as verificações de integridade são expostas no servidor HTTP principal. O senhor pode expô-los em uma interface de rede e porta separadas, definindo `quarkus.management.enabled=true` na configuração do aplicativo. Observe que essa propriedade é uma propriedade de tempo de compilação. O valor não pode ser substituído no tempo de execução."
+msgstr "Por padrão, as verificações de saúde são expostas no servidor HTTP principal. Você pode expô-las em uma interface de rede e porta separadas definindo `quarkus.management.enabled=true` na configuração da sua aplicação. Note que esta propriedade é uma propriedade de build-time. O valor não pode ser sobrescrito em tempo de execução."
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "If you enable the management interface without customizing the management network interface and port, the health checks are exposed under: `http://0.0.0.0:9000/q/health`.\n"
 "You can configure the _path_ (the `health` segment in the previous URL) using the `quarkus.smallrye-health.root-path` property."
-msgstr "Se o senhor ativar a interface de gerenciamento sem personalizar a porta e a interface de rede de gerenciamento, as verificações de integridade serão expostas em: `http://0.0.0.0:9000/q/health` . O senhor pode configurar o _caminho_ (o segmento `health` no URL anterior) usando a propriedade `quarkus.smallrye-health.root-path` ."
+msgstr "Se você habilitar a interface de gerenciamento sem customizar a interface de rede e porta de gerenciamento, as verificações de saúde serão expostas em: `http://0.0.0.0:9000/q/health`. Você pode configurar o _caminho_ (o segmento `health` na URL anterior) usando a propriedade `quarkus.smallrye-health.root-path`."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "Refer to the xref:./management-interface-reference.adoc[management interface reference] for more information."
-msgstr "Consulte a xref:./management-interface-reference.adoc[referência da interface de gerenciamento] para obter mais informações."
+msgstr "Consulte a xref:./management-interface-reference.adoc[referência da interface de gerenciamento] para mais informações."
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy, no-wrap
 msgid "Conclusion"
 msgstr "Conclusão"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
@@ -664,35 +772,39 @@ msgid ""
 "about its healthiness state to state whether it is able to function properly.\n"
 "Liveness checks are utilized to tell whether the application should be restarted and\n"
 "readiness checks are used to tell whether the application is able to process requests."
-msgstr "O SmallRye Health fornece uma maneira de seu aplicativo distribuir informações sobre seu estado de integridade para determinar se ele é capaz de funcionar corretamente. As verificações de vivacidade são utilizadas para saber se o aplicativo deve ser reiniciado e as verificações de prontidão são utilizadas para saber se o aplicativo é capaz de processar solicitações."
+msgstr "SmallRye Health fornece uma maneira para sua aplicação distribuir informações sobre seu estado de saúde para declarar se ela é capaz de funcionar corretamente. Verificações de liveness são utilizadas para dizer se a aplicação deve ser reiniciada e verificações de readiness são usadas para dizer se a aplicação é capaz de processar requisições."
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "All that is needed to enable the SmallRye Health features in Quarkus is:"
-msgstr "Tudo o que é necessário para ativar os recursos do SmallRye Health no Quarkus é:"
+msgstr "Tudo o que é necessário para habilitar os recursos do SmallRye Health no Quarkus é:"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid ""
 "adding the `smallrye-health` Quarkus extension to your project using the\n"
 "`quarkus-maven-plugin`:"
-msgstr "Adicionando a extensão `smallrye-health` do Quarkus ao seu projeto usando o `quarkus-maven-plugin` :"
+msgstr "adicionar a extensão Quarkus `smallrye-health` ao seu projeto usando o `quarkus-maven-plugin`:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
 #, fuzzy
 msgid "or simply adding the following Maven dependency:"
-msgstr "ou simplesmente adicionando a seguinte dependência do Maven:"
+msgstr "ou simplesmente adicionando a seguinte dependência Maven:"
 
-#. type: Title =
+#. type: Title ==
+#. mt: gemini
 #: _guides/smallrye-health.adoc
-#, no-wrap
+#, fuzzy, no-wrap
 msgid "Configuration Reference"
-msgstr "Referência de configuração"
+msgstr "Referência de Configuração"
 
-#. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-health.adoc
+#, fuzzy
 msgid "<span class=\"icon\"><i class=\"fa fa-lock\" title=\"Fixed at build time\"></i></span> Configuration property fixed at build time - All other configuration properties are overridable at runtime <input type=\"search\" id=\"config-search-0\" placeholder=\"FILTER CONFIGURATION\" disabled>"
-msgstr "<span class=\"icon\"><i class=\"fa fa-lock\" title=\"Fixed at build time\"></i></span> Propriedade de Configuração Fixa no Momento da Compilação - Todas as outras propriedades de configuração podem ser sobrepostas em tempo de execução. <input type=\"search\" id=\"config-search-0\" placeholder=\"FILTER CONFIGURATION\" disabled>"
+msgstr "<span class=\"icon\"><i class=\"fa fa-lock\" title=\"Fixo em tempo de compilação\"></i></span> Propriedade de configuração fixa em tempo de compilação - Todas as outras propriedades de configuração podem ser sobrescritas em tempo de execução <input type=\"search\" id=\"config-search-0\" placeholder=\"FILTRAR CONFIGURAÇÃO\" disabled>"


### PR DESCRIPTION
### Summary

This PR is a preview of LLM-based translation experiments using the new tsuji translation utility. We have achieved good translation quality for Japanese documentation, and are now expanding the experiment to Portuguese (pt-BR).

### Background

- **Tool**: Using updated [tsuji](https://github.com/doc-l10n-kit/tsuji) with LLM translation support
- **Translation Engine**: Gemini (gemini-3-flash-preview / gemini-3.1-pro-preview)

### Changes in this PR

Re-translated the following files using Gemini:
- `l10n/po/pt_BR/_guides/mailer-reference.adoc.po`
- `l10n/po/pt_BR/_guides/native-and-ssl.adoc.po`
- `l10n/po/pt_BR/_guides/smallrye-health.adoc.po`

Fuzzy marks are kept as this is a machine translation

### Observed Improvements

From automated analysis by Claude Code, the LLM translations show:
- ✅ More consistent terminology usage
- ✅ Better handling of technical terms
- ✅ Improved markup preservation (Asciidoc links, code blocks)
- ✅ More natural sentence structures
- ✅ Consistent pronoun usage (você vs. o senhor)

### Request for Feedback

**I don't speak Portuguese**, so I need help from native speakers or Portuguese documentation maintainers:

1. **Comparison with Previous Translations**: Has the quality improved compared to the existing machine translations? Are there any regressions?
2. **Translation Quality**: Are there any systematic issues or patterns in the translations that should be corrected?
3. **Style**: Is the tone and formality level appropriate for technical documentation?
4. **Prompt Improvements**: If you notice recurring issues, what rules should be added to the LLM prompts?

### Next Steps

Based on feedback:
- Adjust LLM prompts if needed (located in `config/prompts/`)
- Expand to more files once quality is validated
