### PR TITLE
docs: analysis and translation completed file smallrye-pulsar-outgoing

### DIFF
--- a/l10n/po/pt_BR/_guides/_includes/smallrye-pulsar-outgoing.adoc.po
+++ b/l10n/po/pt_BR/_guides/_includes/smallrye-pulsar-outgoing.adoc.po
@@ -1,14 +1,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2023-09-28 10:38-0300\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-05-25 17:25-0300\n"
 "Last-Translator: George Gastaldi <gegastaldi@gmail.com>\n"
 "Language-Team: \n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #. type: Block title
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
@@ -49,9 +50,9 @@ msgstr "Padrão"
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "*client-configuration*"
-msgstr "*configuração do cliente*"
+msgstr "client-configuration"
 
 #. type: Table
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
@@ -62,7 +63,7 @@ msgstr "Identificador de um bean CDI que fornece a configuração padrão do cli
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "string"
 msgstr "string"
 
@@ -75,9 +76,9 @@ msgstr "falso"
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "*health-enabled*"
-msgstr "*habilitado para a saúde*"
+msgstr "*health-enabled*"
 
 #. type: Table
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
@@ -94,7 +95,7 @@ msgstr "booleano"
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "`true`"
 msgstr "`true`"
 
@@ -119,16 +120,16 @@ msgstr "int"
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "`1000`"
 msgstr "`1000`"
 
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "*producer-configuration*"
-msgstr "*configuração do produtor*"
+msgstr "*producer-configuration*"
 
 #. type: Table
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
@@ -139,9 +140,9 @@ msgstr "Identificador de um bean CDI que fornece a configuração padrão do pro
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "*schema*"
-msgstr "*esquema*"
+msgstr "*schema*"
 
 #. type: Table
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
@@ -152,7 +153,7 @@ msgstr "O tipo de esquema Pulsar deste canal. Quando configurado, um esquema é 
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "*serviceUrl*"
 msgstr "*serviceUrl*"
 
@@ -165,16 +166,16 @@ msgstr "A URL do serviço Pulsar"
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "`pulsar://localhost:6650`"
 msgstr "`pulsar://localhost:6650`"
 
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "*topic*"
-msgstr "*tópico*"
+msgstr "*topic*"
 
 #. type: Table
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
@@ -185,9 +186,9 @@ msgstr "O tópico Pulsar consumido/populado. Se não estiver definido, o nome do
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "*tracing-enabled*"
-msgstr "*habilitado para rastreamento*"
+msgstr "*tracing-enabled*"
 
 #. type: Table
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
@@ -198,7 +199,7 @@ msgstr "Se o rastreamento está habilitado (padrão) ou desabilitado"
 #. type: Table
 #. mt: gemini
 #: _guides/_includes/smallrye-pulsar-outgoing.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "*waitForWriteCompletion*"
 msgstr "*waitForWriteCompletion*"
 


### PR DESCRIPTION
Complete translation of the smallrye-pulsar-outgoing.adoc.po file
Terms and attributes of the tags have been kept in the language standard.

Closes #356