### PR TITLE
docs: revisão da tradução completa do arquivo podman.adoc.po para o pt-BR

### DIFF
--- a/l10n/po/pt_BR/_posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc.po
+++ b/l10n/po/pt_BR/_posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc.po
@@ -15,7 +15,7 @@ msgstr ""
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
 #, no-wrap
 msgid "Configuring Podman for Quarkus Dev Services and Testcontainers on Linux"
-msgstr "Configuração do Podman para os serviços de desenvolvimento do Quarkus e Testcontainers no Linux"
+msgstr "Configuração do Podman para os Quarkus Dev Services e Testcontainers no Linux"
 
 #. type: YAML Front Matter: synopsis
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc

--- a/l10n/po/pt_BR/_posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc.po
+++ b/l10n/po/pt_BR/_posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc.po
@@ -1,70 +1,69 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-08-09 19:42-0300\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
 
 #. type: YAML Front Matter: title
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Configuring Podman for Quarkus Dev Services and Testcontainers on Linux"
 msgstr "Configuração do Podman para os serviços de desenvolvimento do Quarkus e Testcontainers no Linux"
 
 #. type: YAML Front Matter: synopsis
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Expose a Podman service for usage with Quarkus Dev Services and Testcontainers"
 msgstr "Expor um serviço Podman para utilização com Quarkus Dev Services e Testcontainers"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "_Update: For the latest, simpler, instructions on running Podman with Quarkus, see https://quarkus.io/guides/podman[the Quarkus Podman guide]._"
-msgstr "_Atualização: Para obter as instruções mais recentes e mais simples sobre como executar o Podman com o Quarkus, consulte link:https://quarkus.io/guides/podman[o guia do Quarkus Podman] ._"
+msgstr "_Atualização: Para obter as instruções mais recentes e mais simples sobre como executar o Podman com o Quarkus, consulte link:https://quarkus.io/guides/podman[o guia do Quarkus Podman]._"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "Podman is a daemonless container engine for developing, managing, and running Containers on Linux systems. Since the\n"
 "release of version 3, Podman allows the user to run a service emulating a Docker API provided on a  Unix socket. This\n"
 "makes it possible for Testcontainers and Quarkus Dev Services to be utilized with Podman."
-msgstr "O Podman é um mecanismo de contêiner sem daemon para desenvolver, gerenciar e executar contêineres em sistemas Linux. Desde o lançamento da versão 3, o Podman permite que o usuário execute um serviço emulando uma API do Docker fornecida em um soquete Unix. Isso possibilita que o Testcontainers e o Quarkus Dev Services sejam utilizados com o Podman."
+msgstr ""
+"O Podman é um mecanismo de contêiner sem daemon para desenvolver, gerenciar e executar contêineres em sistemas Linux. Desde o\n"
+"lançamento da versão 3, o Podman permite que o usuário execute um serviço emulando uma API do Docker fornecida via um soquete Unix. Isso\n"
+"possibilita que o Testcontainers e o Quarkus Dev Services sejam utilizados com o Podman."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "Directions in this article will not work on macOS and Microsoft Windows."
 msgstr "As instruções deste artigo não funcionam no macOS e no Microsoft Windows."
 
 #. type: Title =
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Requirements"
 msgstr "Requisitos"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "Running on a Linux system with Podman 3.x installed."
-msgstr "Em execução num sistema Linux com o Podman 3.x instalado."
+msgstr "Executando em um sistema Linux com o Podman 3.x instalado."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "`podman-docker` installed to emulate the Docker CLI for Quarkus Dev Services."
 msgstr "`podman-docker` instalado para emular o Docker CLI para o Quarkus Dev Services."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "(optional) `podman-remote` installed for verification steps."
-msgstr "(opcional) `podman-remote` instalado para as etapas de verificação."
+msgstr "(Opcional) `podman-remote` instalado para  etapas de verificação."
 
 #. type: Title =
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
@@ -74,163 +73,181 @@ msgstr "Configuração"
 
 #. type: Title ==
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "TL;DR"
 msgstr "TL;DR"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "The following commands will set up Podman and environment variables up to work with Quarkus Dev Services and\n"
 "Testcontainers:"
-msgstr "Os comandos a seguir configurarão o Podman e as variáveis de ambiente para trabalhar com o Quarkus Dev Services e o Testcontainers:"
+msgstr ""
+"Os comandos a seguir configurarão o Podman e as variáveis de ambiente para trabalhar com o Quarkus Dev Services e\n"
+"o Testcontainers:"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "What this configuration does is explained below, along with basic troubleshooting."
 msgstr "O que esta configuração faz é explicado abaixo, juntamente com a resolução básica de problemas."
 
 #. type: Title ==
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Configuring the Podman service"
-msgstr "Configurar o serviço Podman"
+msgstr "Configuração do serviço Podman"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "Podman is a daemonless container engine. Quarkus Dev Services and Testcontainers expect a running Docker daemon\n"
 "listening at a Unix socket. Since version 3, Podman can be configured to create a service listening at a Unix socket\n"
 "and this service can be used with Dev Services and Testcontainers."
-msgstr "O Podman é um mecanismo de contêiner sem daemon. O Quarkus Dev Services e o Testcontainers esperam um daemon do Docker em execução escutando em um soquete Unix. Desde a versão 3, o Podman pode ser configurado para criar um serviço que escuta em um soquete Unix e esse serviço pode ser usado com Dev Services e Testcontainers."
+msgstr ""
+"O Podman é um mecanismo de contêiner sem daemon. O Quarkus Dev Services e o Testcontainers esperam um daemon\n"
+"do Docker em execução escutando em um soquete Unix. Desde a versão 3, o Podman pode ser configurado para criar um serviço que escutando em um soquete Unix\n"
+"que pode ser usado com Dev Services e Testcontainers."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "By convention, the Docker clients attempt to connect to the service specified by URL configured in the `DOCKER_HOST`\n"
 "environment variable, so this variable needs to be configured to point to the Unix socket that the Podman service will\n"
 "be listening on:"
-msgstr "Por convenção, os clientes do Docker tentam se conectar ao serviço especificado pelo URL configurado na variável de ambiente `DOCKER_HOST` , portanto, essa variável precisa ser configurada para apontar para o soquete Unix no qual o serviço Podman estará escutando:"
+msgstr ""
+"Por convenção, os clientes do Docker tentam se conectar ao serviço especificado pela URL configurada na variável de ambiente `DOCKER_HOST` ,\n"
+"portanto, essa variável precisa ser configurada para apontar para o soquete Unix no qual o serviço Podman estará escutando:"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "This setting will only apply to the current terminal session. To make this configuration persistent, add the line to\n"
 "the profile files of your shell (e.g. `~/.profile`)."
-msgstr "Essa configuração será aplicada somente à sessão atual do terminal. Para tornar essa configuração persistente, adicione a linha aos arquivos de perfil do seu shell (por exemplo, `~/.profile` )."
+msgstr ""
+"Essa configuração será aplicada somente à sessão atual do terminal. Para tornar essa configuração persistente, adicione a linha\n"
+"aos arquivos de perfil do seu shell (por exemplo, `~/.profile` )."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "Testcontainers and Quarkus Dev Services also expect the container service they make requests against to be\n"
 "non-interactive. In case you have multiple registries configured in your Docker or Podman configuration, Podman responds\n"
 "with a prompt asking which registry should be used to pull containers from in case the containers pulled are specified\n"
 "by short name."
-msgstr "O Testcontainers e o Quarkus Dev Services também esperam que o serviço de contêiner ao qual fazem solicitações seja não interativo. Caso tenha vários registros configurados na sua configuração do Docker ou do Podman, o Podman responde com um prompt perguntando qual registro deve ser usado para extrair contêineres, caso os contêineres extraídos sejam especificados por um nome curto."
+msgstr ""
+"O Testcontainers e o Quarkus Dev Services também esperam que o serviço de contêiner ao qual fazem solicitações seja\n"
+"não interativo. Caso tenha vários registros configurados na sua configuração do Docker ou do Podman, o Podman responde\n"
+"com um prompt perguntando qual registro deve ser usado para extrair contêineres, caso os contêineres extraídos sejam especificados\n"
+"por um nome curto."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "You can disable this prompt by setting the `short-name-mode=\"disabled\"` configuration property of Podman in\n"
 "`/etc/containers/registries.conf`."
-msgstr "O senhor pode desativar esse prompt definindo a propriedade de configuração `short-name-mode=\"disabled\"` do Podman em `/etc/containers/registries.conf` ."
+msgstr ""
+"Vocêr pode desativar esse prompt definindo a propriedade de configuração `short-name-mode=\"disabled\"` do Podman em\n"
+"`/etc/containers/registries.conf`."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "This setting is security sensitive. Please see https://www.redhat.com/sysadmin/container-image-short-names[Container image short names in Podman]\n"
 "before changing this setting."
-msgstr "Essa configuração é sensível à segurança. Consulte link:https://www.redhat.com/sysadmin/container-image-short-names[Nomes curtos de imagens de contêineres no Podman] antes de alterar essa configuração."
+msgstr ""
+"Essa configuração é sensível à segurança. Consulte link:https://www.redhat.com/sysadmin/container-image-short-names[Nomes curtos de imagens de contêineres no Podman]\n"
+"antes de alterar essa configuração."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "Finally, let's start the Podman service listening on the socket previously specified by the `DOCKER_HOST` environment\n"
 "variable."
-msgstr "Por fim, vamos iniciar o serviço Podman escutando no soquete especificado anteriormente pela variável de ambiente `DOCKER_HOST` ."
+msgstr ""
+"Por fim, vamos iniciar o serviço do Podman escutando no soquete especificado anteriormente pela variável de ambiente\n"
+"`DOCKER_HOST`."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "Podman is distributed with user-local systemd units on `apt` and `dnf` package managers configured to run a rootless\n"
 "Podman service. This means that the Podman process will be launched only with the privileges of the user you are logged\n"
 "in as, that the containers and configuration are stored in your home directory and that this service listens at\n"
 "`unix:///run/user/$\\{UID\\}/podman/podman.sock`. In most of the Linux distributions, you can enable this service with the\n"
 "following command:"
-msgstr "O Podman é distribuído com unidades systemd locais do usuário nos gerenciadores de pacotes `apt` e `dnf` configurados para executar um serviço Podman sem raiz. Isso significa que o processo do Podman será iniciado somente com os privilégios do usuário com o qual o senhor está conectado, que os contêineres e a configuração são armazenados no seu diretório pessoal e que esse serviço escuta em `unix:///run/user/${UID}/podman/podman.sock` . Na maioria das distribuições Linux, o senhor pode ativar esse serviço com o seguinte comando:"
+msgstr ""
+"O Podman é distribuído com unidades systemd locais do usuário nos gerenciadores de pacotes `apt` e `dnf` configurados para executar um\n"
+"serviço Podman sem root. Isso significa que o processo do Podman será iniciado somente com os privilégios do usuário no qual  você está conectado,\n"
+"que os contêineres e a configuração são armazenados no seu diretório pessoal e que esse serviço escuta em\n"
+"`unix:///run/user/${UID}/podman/podman.sock`. Na maioria das distribuições Linux, você pode ativar esse serviço com o\n"
+"seguinte comando:"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "You can verify that the container service is really running and responding at the URI specified by `DOCKER_HOST` with\n"
 "`podman-remote`."
-msgstr "O senhor pode verificar se o serviço de contêiner está realmente em execução e respondendo no URI especificado por `DOCKER_HOST` com `podman-remote` ."
+msgstr ""
+"Você pode verificar se o serviço de contêiner está realmente em execução e respondendo na URI especificada por `DOCKER_HOST` com\n"
+"`podman-remote`."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "Podman's support for Ryuk container is currently flaky. Ryuk is a container that Testcontainers uses to clean up any\n"
 "containers spawned by Testcontainers after the end of their usage in Java code. You can configure Testcontainers not to\n"
 "use Ryuk."
-msgstr "No momento, o suporte do Podman para o contêiner Ryuk não está funcionando corretamente. O Ryuk é um contêiner que o Testcontainers usa para limpar todos os contêineres gerados pelo Testcontainers após o término de seu uso no código Java. O senhor pode configurar o Testcontainers para não usar o Ryuk."
+msgstr ""
+"No momento, o suporte do Podman para o contêiner Ryuk não está funcionando corretamente. O Ryuk é um contêiner que o Testcontainers usa para limpar todos os\n"
+"contêineres gerados pelo Testcontainers após o término de seu uso no código Java. Você pode configurar o Testcontainers para não\n"
+"usar o Ryuk."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "Podman is now available to respond to the Java Docker client used in Testcontainers. Please note that the Quarkus Dev\n"
 "Services require that a `docker` command is available on `PATH`. The `podman-docker` package on Linux distributions\n"
 "provides a Docker CLI emulation layer for Podman."
-msgstr "O Podman agora está disponível para responder ao cliente Java Docker usado no Testcontainers. Observe que os serviços de desenvolvimento do Quarkus exigem que o comando `docker` esteja disponível em `PATH` . O pacote `podman-docker` nas distribuições Linux fornece uma camada de emulação de CLI do Docker para o Podman."
+msgstr ""
+"O Podman agora está disponível para responder ao cliente Java Docker usado no Testcontainers. Observe que o Quarkus Dev\n"
+"Services exige que o comando `docker` esteja disponível em `PATH`. O pacote `podman-docker` nas distribuições Linux\n"
+"fornece uma camada de emulação de CLI do Docker para o Podman."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "The future releases of Quarkus will remove the expectation for `docker` command available on `PATH`."
-msgstr "As futuras versões do Quarkus eliminarão a expetativa do comando `docker` disponível em `PATH`."
+msgstr "As futuras versões do Quarkus removerão a exigência do comando `docker` disponível em `PATH`."
 
 #. type: Title ==
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Migrating from Docker"
 msgstr "Migrando do Docker"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "If you have previously been running Docker on a version that did not support cgroups V2 on modern Linux distributions,\n"
 "a workaround setting the cgroups to V1 had to be enabled. This applied for Docker versions older than 19, included."
-msgstr "Se o senhor já estava executando o Docker em uma versão que não suportava o cgroups V2 em distribuições Linux modernas, era necessário ativar uma solução alternativa para definir o cgroups como V1. Isso se aplicava às versões do Docker anteriores à 19, inclusive."
+msgstr ""
+"Se você já estava executando o Docker em uma versão que não suportava o cgroups V2 em distribuições Linux modernas,\n"
+"era necessário ativar uma solução alternativa para definir o cgroups como V1. Isso se aplicava às versões do Docker anteriores à 19, inclusive."
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "You can check whether the workaround has been previously applied to your system with the following command:"
-msgstr "Pode verificar se a solução alternativa foi previamente aplicada ao seu sistema com o seguinte comando:"
+msgstr "Você pode verificar se a solução alternativa foi previamente aplicada ao seu sistema com o seguinte comando:"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid ""
 "If the output is present, this means that kernel argument to set cgroups to V1 has been applied. You can remove the\n"
 "kernel argument with the following command, re-enabling cgroups V2:"
-msgstr "Se a saída estiver presente, isso significa que o argumento do kernel para definir cgroups como V1 foi aplicado. O senhor pode remover o argumento do kernel com o seguinte comando, reativando o cgroups V2:"
+msgstr ""
+"Se a saída estiver presente, isso significa que o argumento do kernel para definir cgroups como V1 foi aplicado. Você pode remover o\n"
+"argumento do kernel com o seguinte comando, reativando o cgroups V2:"
 
 #. type: Plain text
 #: _posts/2021-12-03-quarkus-devservices-testcontainers-podman.adoc
-#, fuzzy
 msgid "This setting will only take effect after a reboot."
-msgstr "Esta definição só terá efeito após uma reinicialização."
+msgstr "Esta configuração só terá efeito após uma reinicialização."


### PR DESCRIPTION
Revisão e ajustes de  correção necessários na tradução do arquivo |10n/po/pt_BR/_guides/podman.adoc.po