### PR TITLE
Migrate from Jekyll to ROQ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,12 +40,6 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Cache bundle directory
-        uses: actions/cache@v6
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-
       - name: Cache tsuji.jar
         uses: actions/cache@v6
         with:
@@ -78,7 +72,7 @@ jobs:
         uses: ./.github/actions/push-changes
 
       - name: Update all stats
-        run: ./tsujiw jekyll update-stats
+        run: ./tsujiw roq update-stats
 
       - name: Commit changes (translation stats)
         uses: ./.github/actions/commit-changes
@@ -125,12 +119,6 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Cache bundle directory
-        uses: actions/cache@v6
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-
       - name: Cache tsuji.jar
         uses: actions/cache@v6
         with:
@@ -146,17 +134,17 @@ jobs:
           {
             echo "git_user_name=$(./tsujiw config get tsuji.git.user.name)"
             echo "git_user_email=$(./tsujiw config get tsuji.git.user.email)"
-            echo "jekyll_cname=$(./tsujiw config get tsuji.jekyll.cname)"
+            echo "roq_cname=$(yq -r '.tsuji.roq.cname // ""' config/application.yaml)"
           } >> $GITHUB_OUTPUT
 
       - name: Build
-        run: ./tsujiw jekyll build
+        run: ./tsujiw roq build
 
       - name: Deploy to GitHub Pages
         env:
           GIT_USER_NAME: ${{ steps.config.outputs.git_user_name }}
           GIT_USER_EMAIL: ${{ steps.config.outputs.git_user_email }}
-          GITHUB_PAGES_CNAME: ${{ steps.config.outputs.jekyll_cname }}
+          GITHUB_PAGES_CNAME: ${{ steps.config.outputs.roq_cname }}
         run: |
           if [ -n "$GITHUB_PAGES_CNAME" ]; then
             echo "$GITHUB_PAGES_CNAME" > docs/CNAME

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,12 +38,6 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Cache bundle directory
-        uses: actions/cache@v6
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-
       - name: Cache tsuji.jar
         uses: actions/cache@v6
         with:
@@ -54,25 +48,60 @@ jobs:
         run: bin/setup-build-env-on-ubuntu
 
       - name: Restore mtime
-        # git restore-mtime is currently broken in the GH Actions images so using our own updated local copy
-        # see https://github.com/MestreLion/git-tools/blob/main/git-restore-mtime
         run: |
           cd upstream
           ./tools/git-restore-mtime
 
       - name: Build for preview
-        run: ./tsujiw jekyll build --additional-configs=_only_latest_guides_config.yml
+        run: |
+          QUARKUS_ROQ_GENERATOR_BATCH=true \
+          QUARKUS_PROFILE=only-latest-guides \
+          ./tsujiw roq build
 
       - name: Reduce the size of the website to be compatible with surge
         run: |
-          cd upstream
-          find assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf ../docs/{} \;
-          find newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +50 -exec rm -rf ../docs/{} \;
-          rm -rf ../docs/assets/stickers
-          rm -rf ../docs/assets/images/worldtour/2023
-          rm -rf ../docs/assets/images/worldtour/2024
-          rm -rf ../docs/assets/images/desktopwallpapers
-          rm -rf ../docs/assets/images/stickers
+          SITE_DIR="docs"
+
+          # Keep only the 10 most recent newsletters
+          if [ -d "$SITE_DIR/newsletter" ]; then
+            ls -1 "$SITE_DIR/newsletter" |
+              sort -n |
+              head -n -10 |
+              while read -r dir; do
+                rm -rf "$SITE_DIR/newsletter/$dir"
+              done
+          fi
+
+          CUTOFF=$(date -d '50 days ago' +%Y-%m-%d)
+          RECENT_IMGS=$(mktemp)
+          OLD_IMGS=$(mktemp)
+          POSTS_DIR=upstream/content/posts
+
+          for post in "$POSTS_DIR"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*.adoc; do
+            POST_DATE=$(basename "$post" | grep -oP '^\d{4}-\d{2}-\d{2}')
+            [ -z "$POST_DATE" ] && continue
+
+            if [ "$POST_DATE" \> "$CUTOFF" ]; then
+              grep -oP 'images/posts/\K[^/\["\]]+' "$post" \
+                >> "$RECENT_IMGS" 2>/dev/null || true
+            else
+              grep -oP 'images/posts/\K[^/\["\]]+' "$post" \
+                >> "$OLD_IMGS" 2>/dev/null || true
+            fi
+          done
+
+          comm -23 \
+            <(sort -u "$OLD_IMGS") \
+            <(sort -u "$RECENT_IMGS") |
+            while read -r imgdir; do
+              rm -rf "$SITE_DIR/assets/images/posts/$imgdir"
+            done
+
+          rm -f "$RECENT_IMGS" "$OLD_IMGS"
+
+          rm -rf "$SITE_DIR/assets/stickers"
+          rm -rf "$SITE_DIR/assets/images/desktopwallpapers"
+          rm -rf "$SITE_DIR/assets/images/stickers"
 
       - name: Upload site artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Read surge domain suffix
         id: config
         run: |
-          echo "surge_domain_suffix=$(yq '.tsuji.jekyll.surge-domain-suffix' config/application.yaml)" >> $GITHUB_OUTPUT
+          echo "surge_domain_suffix=$(yq '.tsuji.roq.surge-domain-suffix' config/application.yaml)" >> $GITHUB_OUTPUT
 
       - name: Download site artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -45,7 +45,7 @@ jobs:
           message: "Update upstream"
 
       - name: Update po files
-        run: ./tsujiw jekyll extract
+        run: ./tsujiw roq extract
 
       - name: Commit changes (po files)
         uses: ./.github/actions/commit-changes
@@ -53,7 +53,7 @@ jobs:
           message: "Update .po files"
 
       - name: Update all stats
-        run: ./tsujiw jekyll update-stats
+        run: ./tsujiw roq update-stats
 
       - name: Commit changes (translation stats)
         uses: ./.github/actions/commit-changes

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ out/
 /log/
 # RAG vector index for terminology lookup
 /l10n/rag/
+# ROQ build artifacts
+node_modules/
+target/
 
 ### Local Configuration ###
 .env

--- a/bin/setup-build-env-on-ubuntu
+++ b/bin/setup-build-env-on-ubuntu
@@ -12,14 +12,9 @@ cd $L10N_HOME
 
 # --- Core Build Tools ---
 # - git: version control
-# - git-restore-mtime: improves Jekyll build speed by restoring original timestamps
-sudo apt-get -y install git git-restore-mtime
-
-# --- Jekyll & Ruby Environment ---
-# - ruby-dev: required for native gem extensions
-# - bundler: manages Ruby gems for the static site generator
-sudo apt-get -y install ruby-dev
-sudo gem install bundler
+# - git-restore-mtime: improves build speed by restoring original timestamps
+# - maven: required for ROQ site building
+sudo apt-get -y install git git-restore-mtime maven
 
 # --- Localization Tools ---
 # - po4a: converts between AsciiDoc and PO files

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -3,7 +3,7 @@ quarkus:
     locations: config/application.local.yaml
 
 tsuji:
-  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.8.20/tsuji.jar
+  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.9.1/tsuji.jar
 
   language:
     from: en-US
@@ -23,13 +23,9 @@ tsuji:
       target: pt-BR
 
     target-directories:
-      - _guides
-      - _posts
-      - _versions
+      - content
       - _data
-      - _includes
-      - _layouts
-      - _redirects
+      - templates
 
     gemini:
       model:
@@ -122,6 +118,100 @@ tsuji:
           - _includes/worldtour-abstracts.html
           - _includes/worldtour-code.html
           - _layouts/quarkus3.html
+
+  roq:
+    source-dir: upstream
+    override-dir: l10n/override/pt_BR
+    destination-dir: docs
+    cname: pt.quarkus.io
+    surge-domain-suffix: pt-quarkusio.surge.sh
+    asciidoc-jruby-l10n:
+      version: "2.1.7"
+    stats-sections:
+      main-guides: "content/guides,content/_generated-doc"
+      posts: "content/posts"
+      misc: "content,_data,templates"
+    extract:
+      yaml:
+        exclude:
+          - _data/authors.yaml
+          - _data/languages.yaml
+          - _data/publications.yaml
+          - _data/versions.yaml
+          - _data/contributors.yaml
+          - _data/versioned/2-16/index/quarkus.yaml
+          - _data/versioned/3-2/index/quarkus.yaml
+          - _data/versioned/3-8/index/quarkiverse.yaml
+          - _data/versioned/3-8/index/quarkus.yaml
+          - _data/versioned/3-8/index/relations.yaml
+          - _data/versioned/3-15/index/quarkus.yaml
+          - _data/versioned/3-15/index/relations.yaml
+          - _data/versioned/3-20/index/quarkus.yaml
+          - _data/versioned/3-20/index/relations.yaml
+          - _data/versioned/3-27/index/quarkus.yaml
+          - _data/versioned/3-27/index/relations.yaml
+          - _data/versioned/3-33/index/quarkus.yaml
+          - _data/versioned/3-33/index/relations.yaml
+          - _data/versioned/3-34/index/quarkus.yaml
+          - _data/versioned/3-34/index/relations.yaml
+          - _data/versioned/latest/index/quarkiverse.yaml
+          - _data/versioned/latest/index/quarkus.yaml
+          - _data/versioned/latest/index/relations.yaml
+          - _data/versioned/main/index/quarkiverse.yaml
+          - _data/versioned/main/index/quarkus.yaml
+          - _data/versioned/main/index/relations.yaml
+      html:
+        include:
+          - templates/partials/about.html
+          - templates/partials/ai-blueprints.html
+          - templates/partials/ai-chainofthought.html
+          - templates/partials/ai-contextualrag.html
+          - templates/partials/ai-frozenrag.html
+          - templates/partials/ai-java-for-ai.html
+          - templates/partials/ai-overview.html
+          - templates/partials/ai-quarkus-for-ai.html
+          - templates/partials/benefactors.html
+          - templates/partials/catalog-detail-band.html
+          - templates/partials/catalog-index-band.html
+          - templates/partials/commonhaus-footerband.html
+          - templates/partials/container-first.html
+          - templates/partials/developer-joy.html
+          - templates/partials/discussion.html
+          - templates/partials/events-discussions-band.html
+          - templates/partials/feedback-community-band.html
+          - templates/partials/get-started-band.html
+          - templates/partials/get-started-band-lightblue.html
+          - templates/partials/get-started-code-steps.html
+          - templates/partials/header-navigation.html
+          - templates/partials/homepage-ai-band.html
+          - templates/partials/homepage-commonhaus-band.html
+          - templates/partials/homepage-container_first-band.html
+          - templates/partials/homepage-developer_joy-band.html
+          - templates/partials/homepage-extensions-band.html
+          - templates/partials/homepage-features-band.html
+          - templates/partials/homepage-features-icon-band.html
+          - templates/partials/homepage-hero-band.html
+          - templates/partials/homepage-hero-band-ssjprime.html
+          - templates/partials/homepage-hero-newrelease-band.html
+          - templates/partials/homepage-imperative_and_reactive-band.html
+          - templates/partials/homepage-performance-band.html
+          - templates/partials/homepage-userstory-callout.html
+          - templates/partials/insights-band.html
+          - templates/partials/kubernetes-native.html
+          - templates/partials/newsletter-band.html
+          - templates/partials/performance.html
+          - templates/partials/project-footer.html
+          - templates/partials/publication-entries.html
+          - templates/partials/spring-features-band.html
+          - templates/partials/spring-migrate-books.html
+          - templates/partials/spring-migrate-content.html
+          - templates/partials/spring-userstory-callout.html
+          - templates/partials/standards.html
+          - templates/partials/support-help-band.html
+          - templates/partials/support-options-band.html
+          - templates/partials/training-band.html
+          - templates/partials/userstories-band.html
+          - templates/layouts/quarkus3.html
 
   git:
     user:


### PR DESCRIPTION
Upstream quarkus.io has migrated from Jekyll to ROQ (Quarkus-based static site generator). Update all workflows to use tsuji's ROQ commands, replace Ruby/Bundler with Maven in the build environment, and bump tsuji to v0.9.1 which includes ROQ support.