### PR TITLE
Fix PR lookup for fork previews

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -26,11 +26,17 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const prs = context.payload.workflow_run.pull_requests;
-            if (!prs || prs.length === 0) {
-              core.setFailed('No pull request found for this workflow run');
+            const { data: prs } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                ...context.repo,
+                commit_sha: context.payload.workflow_run.head_sha
+              });
+
+            if (prs.length !== 1) {
+              core.setFailed(`Expected one pull request, found ${prs.length}`);
               return;
             }
+
             core.setOutput('pr_number', prs[0].number);
 
       - name: Read surge domain suffix


### PR DESCRIPTION
Use the workflow run head SHA to find the associated pull request. This allows preview deployments to resolve PR numbers when the workflow is triggered by a fork.