### PR TITLE
Fix trailing newline in PO translations that break the site build

### DIFF
--- a/l10n/po/pt_BR/_guides/openapi-swaggerui.adoc.po
+++ b/l10n/po/pt_BR/_guides/openapi-swaggerui.adoc.po
@@ -1182,7 +1182,7 @@ msgstr "ordem"
 #. type: Plain text
 #: _guides/openapi-swaggerui.adoc
 msgid "user"
-msgstr "user\n"
+msgstr "user"
 
 #. type: Plain text
 #. mt: gemini

--- a/l10n/po/pt_BR/_posts/2023-03-30-quarkus-3-0-0-cr1-released.adoc.po
+++ b/l10n/po/pt_BR/_posts/2023-03-30-quarkus-3-0-0-cr1-released.adoc.po
@@ -111,7 +111,7 @@ msgstr "O ponto final está disponível em `/q/info` e será exposto na interfac
 #: _posts/2023-03-30-quarkus-3-0-0-cr1-released.adoc
 #, no-wrap
 msgid "quarkus update"
-msgstr "quarkus update\n"
+msgstr "quarkus update"
 
 #. type: Plain text
 #: _posts/2023-03-30-quarkus-3-0-0-cr1-released.adoc

--- a/l10n/po/pt_BR/_versions/3.33/guides/openapi-swaggerui.adoc.po
+++ b/l10n/po/pt_BR/_versions/3.33/guides/openapi-swaggerui.adoc.po
@@ -1022,7 +1022,7 @@ msgstr "ordem"
 #. type: Plain text
 #: _versions/3.33/guides/openapi-swaggerui.adoc
 msgid "user"
-msgstr "user\n"
+msgstr "user"
 
 #. type: Plain text
 #: _versions/3.33/guides/openapi-swaggerui.adoc

--- a/l10n/po/pt_BR/_versions/main/guides/openapi-swaggerui.adoc.po
+++ b/l10n/po/pt_BR/_versions/main/guides/openapi-swaggerui.adoc.po
@@ -1020,7 +1020,7 @@ msgstr "ordem"
 #. type: Plain text
 #: _versions/main/guides/openapi-swaggerui.adoc
 msgid "user"
-msgstr "user\n"
+msgstr "user"
 
 #. type: Plain text
 #: _versions/main/guides/openapi-swaggerui.adoc

--- a/l10n/po/pt_BR/content/404.md.po
+++ b/l10n/po/pt_BR/content/404.md.po
@@ -43,4 +43,4 @@ msgstr "Você não encontrou nenhum lugar.<br/>O caminho para o espaço normal<b
 #: content/404.md:11
 #, no-wrap
 msgid "A haiku for you.\n"
-msgstr "Um haiku para você."
+msgstr "Um haiku para você.\n"

--- a/l10n/po/pt_BR/content/guides/openapi-swaggerui.adoc.po
+++ b/l10n/po/pt_BR/content/guides/openapi-swaggerui.adoc.po
@@ -737,7 +737,7 @@ msgid "order"
 msgstr "ordem"
 
 msgid "user"
-msgstr "user\n"
+msgstr "user"
 
 #, fuzzy
 msgid "You may want to change this to more user-friendly names, based on your requirements. For example, changing the options in the dropdown to \"Intro\", \"Order Service\", \"User Service\" would look like this:"

--- a/l10n/po/pt_BR/content/posts/2023-03-30-quarkus-3-0-0-cr1-released.adoc.po
+++ b/l10n/po/pt_BR/content/posts/2023-03-30-quarkus-3-0-0-cr1-released.adoc.po
@@ -66,7 +66,7 @@ msgid "The endpoint is available on `/q/info` and will be exposed on the managem
 msgstr "O ponto final está disponível em `/q/info` e será exposto na interface de rede de gestão se o ativar."
 
 msgid "quarkus update"
-msgstr "quarkus update\n"
+msgstr "quarkus update"
 
 #, fuzzy
 msgid ""

--- a/l10n/po/pt_BR/content/versions/3.33/guides/openapi-swaggerui.adoc.po
+++ b/l10n/po/pt_BR/content/versions/3.33/guides/openapi-swaggerui.adoc.po
@@ -737,7 +737,7 @@ msgid "order"
 msgstr "ordem"
 
 msgid "user"
-msgstr "user\n"
+msgstr "user"
 
 #, fuzzy
 msgid "You may want to change this to more user-friendly names, based on your requirements. For example, changing the options in the dropdown to \"Intro\", \"Order Service\", \"User Service\" would look like this:"

--- a/l10n/po/pt_BR/content/versions/3.34/guides/openapi-swaggerui.adoc.po
+++ b/l10n/po/pt_BR/content/versions/3.34/guides/openapi-swaggerui.adoc.po
@@ -737,7 +737,7 @@ msgid "order"
 msgstr "ordem"
 
 msgid "user"
-msgstr "user\n"
+msgstr "user"
 
 #, fuzzy
 msgid "You may want to change this to more user-friendly names, based on your requirements. For example, changing the options in the dropdown to \"Intro\", \"Order Service\", \"User Service\" would look like this:"

--- a/l10n/po/pt_BR/content/versions/main/guides/openapi-swaggerui.adoc.po
+++ b/l10n/po/pt_BR/content/versions/main/guides/openapi-swaggerui.adoc.po
@@ -749,7 +749,7 @@ msgid "order"
 msgstr "ordem"
 
 msgid "user"
-msgstr "user\n"
+msgstr "user"
 
 #, fuzzy
 msgid "You may want to change this to more user-friendly names, based on your requirements. For example, changing the options in the dropdown to \"Intro\", \"Order Service\", \"User Service\" would look like this:"


### PR DESCRIPTION
gettext requires msgid and msgstr to both end with a newline or neither. Ten entries violate that, so msgfmt rejects the file and po4a-translate aborts the build:

    content/404.md.po:46: 'msgid' and 'msgstr' entries do not both end with '\n'

Six are under content/, written when the Roq migration reached us in d459dfaa7 and apply-tmx repopulated the re-extracted tree. Four are older, in the legacy tree that tmx generate still scans. This aligns each translation with its message id and touches nothing else, no fuzzy flag included. The root cause is in tsuji's TMX lookup, so this repairs the committed data only.
